### PR TITLE
libdrm: Add libdrm-tegra as alternative

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-libraries_28.1.0.bb
+++ b/recipes-bsp/tegra-binaries/tegra-libraries_28.1.0.bb
@@ -3,7 +3,7 @@ require tegra-shared-binaries.inc
 
 DEPENDS = "patchelf-native"
 
-inherit update-rc.d systemd
+inherit update-rc.d systemd update-alternatives
 
 do_configure() {
     tar -C ${B} -x -f ${S}/nv_tegra/nvidia_drivers.tbz2 usr/lib usr/sbin usr/share/egl var/nvidia
@@ -53,6 +53,14 @@ do_install() {
     install -d ${D}${datadir}/egl/egl_external_platform.d
     install -m644 ${B}/usr/share/egl/egl_external_platform.d/* ${D}${datadir}/egl/egl_external_platform.d/
 }
+
+# Allow switching between libdrm from freedesktop and libdrm from NVIDIA.
+# freedesktop is the default provider.
+ALTERNATIVE_libdrm-tegra = "libdrm.so.2 libdrm.so.2.4.0"
+ALTERNATIVE_LINK_NAME[libdrm.so.2] = "${libdir}/libdrm.so.2"
+ALTERNATIVE_LINK_NAME[libdrm.so.2.4.0] = "${libdir}/libdrm.so.2.4.0"
+ALTERNATIVE_TARGET = "${libdir}/libdrm-tegra.so.2"
+ALTERNATIVE_PRIORITY = "10"
 
 PACKAGES = "${PN}-libv4l-plugins ${PN}-argus libdrm-tegra libdrm-tegra-dev ${PN}"
 

--- a/recipes-graphics/drm/libdrm_2.4.75.bbappend
+++ b/recipes-graphics/drm/libdrm_2.4.75.bbappend
@@ -1,0 +1,15 @@
+inherit update-alternatives
+
+do_install_append() {
+    mv ${D}${libdir}/libdrm.so.2.4.0 ${D}${libdir}/libdrm-freedesktop.so.2.4.0
+    rm ${D}${libdir}/libdrm.so
+    rm ${D}${libdir}/libdrm.so.2
+    ln -sf libdrm-freedesktop.so.2.4.0 ${D}${libdir}/libdrm.so
+    ln -sf libdrm.so.2.4.0 ${D}${libdir}/libdrm.so.2
+}
+
+ALTERNATIVE_${PN} = "libdrm.so.2.4.0 libdrm.so.2"
+ALTERNATIVE_LINK_NAME[libdrm.so.2.4.0] = "${libdir}/libdrm.so.2.4.0"
+ALTERNATIVE_LINK_NAME[libdrm.so.2] = "${libdir}/libdrm.so.2"
+ALTERNATIVE_TARGET = "${libdir}/libdrm-freedesktop.so.2.4.0"
+ALTERNATIVE_PRIORITY = "20"


### PR DESCRIPTION
The alternative with the highest priority is selected. By default, the
freedesktop alternative has priotity 20, and the tegra alternative has
priority 10.

See the update-alternatives bbclass for information on how to change the
priorities

Signed-off-by: Jonatan Pålsson <jonatan.palsson@pelagicore.com>