### PR TITLE
linux-tegra_4.4.bb: Change AUTOREV to specific commit hash

### DIFF
--- a/recipes-kernel/linux/linux-tegra_4.4.bb
+++ b/recipes-kernel/linux/linux-tegra_4.4.bb
@@ -17,7 +17,7 @@ SCMVERSION ??= "y"
 export LOCALVERSION = ""
 
 SRCBRANCH = "patches-${L4T_VERSION}"
-SRCREV = "${AUTOREV}"
+SRCREV = "79e4600e81c229ee8f9fc9a6f5703b7958f594f0"
 KERNEL_REPO = "github.com/madisongh/linux-tegra.git"
 SRC_URI = "git://${KERNEL_REPO};branch=${SRCBRANCH} \
 	   file://defconfig \


### PR DESCRIPTION
Having AUTOREV prevents yocto reproducible offline builds
based on previous downloaded sources.

This is important when releasing the sources to customer and guarantee
that
it's the same source code used in their released binaries.

Having a floating AUTOREV means less control over the source code used.