### PR TITLE
Fix #46 by setting 4K alignment for ROOTFS

### DIFF
--- a/conf/machine/include/tegra210.inc
+++ b/conf/machine/include/tegra210.inc
@@ -38,6 +38,7 @@ LICENSE_FLAGS_WHITELIST_append = " commercial_gstreamer1.0-omx-tegra"
 
 KERNEL_MODULE_AUTOLOAD = ""
 
+IMAGE_ROOTFS_ALIGNMENT ?= "4"
 NVIDIA_CHIP = "0x21"
 
 CUDA_VERSION ?= "8.0"


### PR DESCRIPTION
As stated in meta/classes/image_types.bbclass:7, IMAGE_ROOTFS_ALIGNMENT is in KB.