### PR TITLE
linux-tegra: add GCC 8 support

### DIFF
--- a/recipes-kernel/linux/linux-tegra-4.4/0001-give-up-on-gcc-ilog2-constant-optimizations.patch
+++ b/recipes-kernel/linux/linux-tegra-4.4/0001-give-up-on-gcc-ilog2-constant-optimizations.patch
@@ -1,0 +1,128 @@
+From 8ab6958e191dca91d9ecc1de92cdf71efa3e2a7a Mon Sep 17 00:00:00 2001
+From: Linus Torvalds <torvalds@linux-foundation.org>
+Date: Thu, 2 Mar 2017 12:17:22 -0800
+Subject: [PATCH] give up on gcc ilog2() constant optimizations
+
+gcc-7 has an "optimization" pass that completely screws up, and
+generates the code expansion for the (impossible) case of calling
+ilog2() with a zero constant, even when the code gcc compiles does not
+actually have a zero constant.
+
+And we try to generate a compile-time error for anybody doing ilog2() on
+a constant where that doesn't make sense (be it zero or negative).  So
+now gcc7 will fail the build due to our sanity checking, because it
+created that constant-zero case that didn't actually exist in the source
+code.
+
+There's a whole long discussion on the kernel mailing about how to work
+around this gcc bug.  The gcc people themselevs have discussed their
+"feature" in
+
+   https://gcc.gnu.org/bugzilla/show_bug.cgi?id=72785
+
+but it's all water under the bridge, because while it looked at one
+point like it would be solved by the time gcc7 was released, that was
+not to be.
+
+So now we have to deal with this compiler braindamage.
+
+And the only simple approach seems to be to just delete the code that
+tries to warn about bad uses of ilog2().
+
+So now "ilog2()" will just return 0 not just for the value 1, but for
+any non-positive value too.
+
+It's not like I can recall anybody having ever actually tried to use
+this function on any invalid value, but maybe the sanity check just
+meant that such code never made it out in public.
+
+Reported-by: Laura Abbott <labbott@redhat.com>
+Cc: John Stultz <john.stultz@linaro.org>,
+Cc: Thomas Gleixner <tglx@linutronix.de>
+Cc: Ard Biesheuvel <ard.biesheuvel@linaro.org>
+Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>
+Signed-off-by: Martin Kelly <mkelly@xevo.com>
+---
+ include/linux/log2.h       | 13 ++-----------
+ tools/include/linux/log2.h | 13 ++-----------
+ 2 files changed, 4 insertions(+), 22 deletions(-)
+
+diff --git a/include/linux/log2.h b/include/linux/log2.h
+index fd7ff3d91e6a..f38fae23bdac 100644
+--- a/include/linux/log2.h
++++ b/include/linux/log2.h
+@@ -16,12 +16,6 @@
+ #include <linux/bitops.h>
+
+ /*
+- * deal with unrepresentable constant logarithms
+- */
+-extern __attribute__((const, noreturn))
+-int ____ilog2_NaN(void);
+-
+-/*
+  * non-constant log of base 2 calculators
+  * - the arch may override these in asm/bitops.h if they can be implemented
+  *   more efficiently than using fls() and fls64()
+@@ -85,7 +79,7 @@ unsigned long __rounddown_pow_of_two(unsigned long n)
+ #define ilog2(n)				\
+ (						\
+ 	__builtin_constant_p(n) ? (		\
+-		(n) < 1 ? ____ilog2_NaN() :	\
++		(n) < 2 ? 0 :			\
+ 		(n) & (1ULL << 63) ? 63 :	\
+ 		(n) & (1ULL << 62) ? 62 :	\
+ 		(n) & (1ULL << 61) ? 61 :	\
+@@ -148,10 +142,7 @@ unsigned long __rounddown_pow_of_two(unsigned long n)
+ 		(n) & (1ULL <<  4) ?  4 :	\
+ 		(n) & (1ULL <<  3) ?  3 :	\
+ 		(n) & (1ULL <<  2) ?  2 :	\
+-		(n) & (1ULL <<  1) ?  1 :	\
+-		(n) & (1ULL <<  0) ?  0 :	\
+-		____ilog2_NaN()			\
+-				   ) :		\
++		1 ) :				\
+ 	(sizeof(n) <= 4) ?			\
+ 	__ilog2_u32(n) :			\
+ 	__ilog2_u64(n)				\
+diff --git a/tools/include/linux/log2.h b/tools/include/linux/log2.h
+index 41446668ccce..d5677d39c1e4 100644
+--- a/tools/include/linux/log2.h
++++ b/tools/include/linux/log2.h
+@@ -13,12 +13,6 @@
+ #define _TOOLS_LINUX_LOG2_H
+
+ /*
+- * deal with unrepresentable constant logarithms
+- */
+-extern __attribute__((const, noreturn))
+-int ____ilog2_NaN(void);
+-
+-/*
+  * non-constant log of base 2 calculators
+  * - the arch may override these in asm/bitops.h if they can be implemented
+  *   more efficiently than using fls() and fls64()
+@@ -78,7 +72,7 @@ unsigned long __rounddown_pow_of_two(unsigned long n)
+ #define ilog2(n)				\
+ (						\
+ 	__builtin_constant_p(n) ? (		\
+-		(n) < 1 ? ____ilog2_NaN() :	\
++		(n) < 2 ? 0 :			\
+ 		(n) & (1ULL << 63) ? 63 :	\
+ 		(n) & (1ULL << 62) ? 62 :	\
+ 		(n) & (1ULL << 61) ? 61 :	\
+@@ -141,10 +135,7 @@ unsigned long __rounddown_pow_of_two(unsigned long n)
+ 		(n) & (1ULL <<  4) ?  4 :	\
+ 		(n) & (1ULL <<  3) ?  3 :	\
+ 		(n) & (1ULL <<  2) ?  2 :	\
+-		(n) & (1ULL <<  1) ?  1 :	\
+-		(n) & (1ULL <<  0) ?  0 :	\
+-		____ilog2_NaN()			\
+-				   ) :		\
++		1 ) :				\
+ 	(sizeof(n) <= 4) ?			\
+ 	__ilog2_u32(n) :			\
+ 	__ilog2_u64(n)				\
+--
+2.11.0
+

--- a/recipes-kernel/linux/linux-tegra-4.4/0002-Kbuild-suppress-packed-not-aligned-warning-for-defau.patch
+++ b/recipes-kernel/linux/linux-tegra-4.4/0002-Kbuild-suppress-packed-not-aligned-warning-for-defau.patch
@@ -1,0 +1,54 @@
+From 18123fb904d0f59b21db229df96bf3237f6360d9 Mon Sep 17 00:00:00 2001
+From: Xiongfeng Wang <xiongfeng.wang@linaro.org>
+Date: Thu, 11 Jan 2018 17:22:29 +0800
+Subject: [PATCH] Kbuild: suppress packed-not-aligned warning for default
+ setting only
+
+gcc-8 reports many -Wpacked-not-aligned warnings. The below are some
+examples.
+
+./include/linux/ceph/msgr.h:67:1: warning: alignment 1 of 'struct
+ceph_entity_addr' is less than 8 [-Wpacked-not-aligned]
+ } __attribute__ ((packed));
+
+./include/linux/ceph/msgr.h:67:1: warning: alignment 1 of 'struct
+ceph_entity_addr' is less than 8 [-Wpacked-not-aligned]
+ } __attribute__ ((packed));
+
+./include/linux/ceph/msgr.h:67:1: warning: alignment 1 of 'struct
+ceph_entity_addr' is less than 8 [-Wpacked-not-aligned]
+ } __attribute__ ((packed));
+
+This patch suppresses this kind of warnings for default setting.
+
+Signed-off-by: Xiongfeng Wang <xiongfeng.wang@linaro.org>
+Signed-off-by: Masahiro Yamada <yamada.masahiro@socionext.com>
+Signed-off-by: Martin Kelly <mkelly@xevo.com>
+---
+ scripts/Makefile.extrawarn | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/scripts/Makefile.extrawarn b/scripts/Makefile.extrawarn
+index da3386a9d244..74e7a808cf59 100644
+--- a/scripts/Makefile.extrawarn
++++ b/scripts/Makefile.extrawarn
+@@ -10,6 +10,8 @@
+ # are not supported by all versions of the compiler
+ # ==========================================================================
+
++KBUILD_CFLAGS += $(call cc-disable-warning, packed-not-aligned)
++
+ ifeq ("$(origin W)", "command line")
+   export KBUILD_ENABLE_EXTRA_GCC_CHECKS := $(W)
+ endif
+@@ -25,6 +27,7 @@ warning-1 += -Wold-style-definition
+ warning-1 += $(call cc-option, -Wmissing-include-dirs)
+ warning-1 += $(call cc-option, -Wunused-but-set-variable)
+ warning-1 += $(call cc-option, -Wunused-const-variable)
++warning-1 += $(call cc-option, -Wpacked-not-aligned)
+ warning-1 += $(call cc-disable-warning, missing-field-initializers)
+
+ warning-2 := -Waggregate-return
+--
+2.11.0
+

--- a/recipes-kernel/linux/linux-tegra-4.4/0003-kbuild-don-t-warn-on-Wattribute-alias.patch
+++ b/recipes-kernel/linux/linux-tegra-4.4/0003-kbuild-don-t-warn-on-Wattribute-alias.patch
@@ -1,0 +1,41 @@
+From 2d7117629d7a06fb27b2d71681eebb256809bfaf Mon Sep 17 00:00:00 2001
+From: Martin Kelly <mkelly@xevo.com>
+Date: Tue, 24 Jul 2018 15:20:16 -0700
+Subject: [PATCH] kbuild: don't warn on -Wattribute-alias
+
+Currently, -Wattribute-alias causes a variety of warnings that are
+breaking the build. This is getting sorted out on LKML, but as far as I
+can tell, no patch for it has yet been merged. For more context, see
+https://lkml.org/lkml/2017/12/5/538.
+
+In the meantime, disable the warning. We should drop this patch when a
+proper fix has been merged into the kernel.
+
+Signed-off-by: Martin Kelly <mkelly@xevo.com>
+---
+ scripts/Makefile.extrawarn | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/scripts/Makefile.extrawarn b/scripts/Makefile.extrawarn
+index 74e7a808cf59..8b43b42f49a1 100644
+--- a/scripts/Makefile.extrawarn
++++ b/scripts/Makefile.extrawarn
+@@ -11,6 +11,7 @@
+ # ==========================================================================
+
+ KBUILD_CFLAGS += $(call cc-disable-warning, packed-not-aligned)
++KBUILD_CFLAGS += $(call cc-disable-warning, attribute-alias)
+
+ ifeq ("$(origin W)", "command line")
+   export KBUILD_ENABLE_EXTRA_GCC_CHECKS := $(W)
+@@ -28,6 +29,7 @@ warning-1 += $(call cc-option, -Wmissing-include-dirs)
+ warning-1 += $(call cc-option, -Wunused-but-set-variable)
+ warning-1 += $(call cc-option, -Wunused-const-variable)
+ warning-1 += $(call cc-option, -Wpacked-not-aligned)
++warning-1 += $(call cc-option, -Wattribute-alias)
+ warning-1 += $(call cc-disable-warning, missing-field-initializers)
+
+ warning-2 := -Waggregate-return
+--
+2.11.0
+

--- a/recipes-kernel/linux/linux-tegra-4.4/0004-kbuild-don-t-warn-on-Wstringop-truncation.patch
+++ b/recipes-kernel/linux/linux-tegra-4.4/0004-kbuild-don-t-warn-on-Wstringop-truncation.patch
@@ -1,0 +1,39 @@
+From f27c99ce6500c4224db93e017bdc0983bd9b3a2e Mon Sep 17 00:00:00 2001
+From: Martin Kelly <mkelly@xevo.com>
+Date: Tue, 24 Jul 2018 15:15:57 -0700
+Subject: [PATCH] kbuild: don't warn on -Wstringop-truncation
+
+Currently, -Wstringop-truncation causes a variety of warnings that are
+breaking the build. Such issues are getting sorted out across the
+subsystems one-by-one, but cherry-picking each patch individually would
+be a lot of work and invite merge conflicts. So for this release, just
+suppress the warning.
+
+Signed-off-by: Martin Kelly <mkelly@xevo.com>
+---
+ scripts/Makefile.extrawarn | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/scripts/Makefile.extrawarn b/scripts/Makefile.extrawarn
+index 8b43b42f49a1..2ec04d58abde 100644
+--- a/scripts/Makefile.extrawarn
++++ b/scripts/Makefile.extrawarn
+@@ -12,6 +12,7 @@
+
+ KBUILD_CFLAGS += $(call cc-disable-warning, packed-not-aligned)
+ KBUILD_CFLAGS += $(call cc-disable-warning, attribute-alias)
++KBUILD_CFLAGS += $(call cc-disable-warning, stringop-truncation)
+
+ ifeq ("$(origin W)", "command line")
+   export KBUILD_ENABLE_EXTRA_GCC_CHECKS := $(W)
+@@ -30,6 +31,7 @@ warning-1 += $(call cc-option, -Wunused-but-set-variable)
+ warning-1 += $(call cc-option, -Wunused-const-variable)
+ warning-1 += $(call cc-option, -Wpacked-not-aligned)
+ warning-1 += $(call cc-option, -Wattribute-alias)
++warning-1 += $(call cc-option, -Wstringop-truncation)
+ warning-1 += $(call cc-disable-warning, missing-field-initializers)
+
+ warning-2 := -Waggregate-return
+--
+2.11.0
+

--- a/recipes-kernel/linux/linux-tegra-4.4/0005-kbuild-don-t-warn-on-Wstringop-overflow.patch
+++ b/recipes-kernel/linux/linux-tegra-4.4/0005-kbuild-don-t-warn-on-Wstringop-overflow.patch
@@ -1,0 +1,40 @@
+From 38ac5a971d89ee9158d844f8505210afde7e930d Mon Sep 17 00:00:00 2001
+From: Martin Kelly <mkelly@xevo.com>
+Date: Tue, 24 Jul 2018 15:31:54 -0700
+Subject: [PATCH] kbuild: don't warn on -Wstringop-overflow
+
+Currently, -Wstringop-overflow causes a variety of warnings that are breaking
+the build. This is getting sorted out on LKML, but as far as I can tell, no
+patch for it has yet been merged.
+
+In the meantime, disable the warning. We should drop this patch when a
+proper fix has been merged into the kernel.
+
+Signed-off-by: Martin Kelly <mkelly@xevo.com>
+---
+ scripts/Makefile.extrawarn | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/scripts/Makefile.extrawarn b/scripts/Makefile.extrawarn
+index 2ec04d58abde..80d2d1fe3d7a 100644
+--- a/scripts/Makefile.extrawarn
++++ b/scripts/Makefile.extrawarn
+@@ -13,6 +13,7 @@
+ KBUILD_CFLAGS += $(call cc-disable-warning, packed-not-aligned)
+ KBUILD_CFLAGS += $(call cc-disable-warning, attribute-alias)
+ KBUILD_CFLAGS += $(call cc-disable-warning, stringop-truncation)
++KBUILD_CFLAGS += $(call cc-disable-warning, stringop-overflow)
+ 
+ ifeq ("$(origin W)", "command line")
+   export KBUILD_ENABLE_EXTRA_GCC_CHECKS := $(W)
+@@ -32,6 +33,7 @@ warning-1 += $(call cc-option, -Wunused-const-variable)
+ warning-1 += $(call cc-option, -Wpacked-not-aligned)
+ warning-1 += $(call cc-option, -Wattribute-alias)
+ warning-1 += $(call cc-option, -Wstringop-truncation)
++warning-1 += $(call cc-option, -Wstringop-overflow)
+ warning-1 += $(call cc-disable-warning, missing-field-initializers)
+ 
+ warning-2 := -Waggregate-return
+-- 
+2.11.0
+

--- a/recipes-kernel/linux/linux-tegra_4.4.bb
+++ b/recipes-kernel/linux/linux-tegra_4.4.bb
@@ -18,8 +18,13 @@ SRCBRANCH = "patches-${L4T_VERSION}"
 SRCREV = "174510d4ad9b4d9b8f1c6e521d34a30ccb7ebab5"
 KERNEL_REPO = "github.com/madisongh/linux-tegra.git"
 SRC_URI = "git://${KERNEL_REPO};branch=${SRCBRANCH} \
-	   file://defconfig \
-"
+           file://defconfig \
+           file://0001-give-up-on-gcc-ilog2-constant-optimizations.patch \
+           file://0002-Kbuild-suppress-packed-not-aligned-warning-for-defau.patch \
+           file://0003-kbuild-don-t-warn-on-Wattribute-alias.patch \
+           file://0004-kbuild-don-t-warn-on-Wstringop-truncation.patch \
+           file://0005-kbuild-don-t-warn-on-Wstringop-overflow.patch \
+           "
 S = "${WORKDIR}/git"
 
 KERNEL_ROOTSPEC ?= "root=/dev/mmcblk\${devnum}p1 rw rootwait"


### PR DESCRIPTION
There are a number of GCC 8-related compile issues. With these patches,
linux-tegra compiles properly with GCC 8. These patches are mostly
workarounds, as the final fixes are either not yet merged upstream or
many patches, which will likely cause merge conflicts. When we move to
another Linux kernel version, we should drop these patches.

Signed-off-by: Martin Kelly <mkelly@xevo.com>