### PR TITLE
alsa-state: add the missing tegra-configs-alsa-21.6 package

### DIFF
--- a/conf/machine/jetson-tk1.conf
+++ b/conf/machine/jetson-tk1.conf
@@ -22,4 +22,4 @@ NVIDIA_BOARD ?= "ardbeg"
 PARTITION_LAYOUT_TEMPLATE ?= "gnu_linux_fastboot_emmc_full.cfg"
 IMAGE_TEGRAFLASH_FS_TYPE ?= "ext3"
 
-ASOUND_CONF_DEFAULT ?= "tegrart5639"
+TEGRA_AUDIO_DEVICE ?= "tegrart5639"

--- a/recipes-bsp/tegra-binaries/tegra-configs-alsa_21.6.0.bb
+++ b/recipes-bsp/tegra-binaries/tegra-configs-alsa_21.6.0.bb
@@ -1,0 +1,24 @@
+require tegra-binaries-${PV}.inc
+require tegra-shared-binaries.inc
+
+DESCRIPTION = "Sound configuration files provided by L4T"
+
+inherit systemd
+
+do_configure() {
+    tar -C ${B} -x -f ${S}/nv_tegra/config.tbz2 etc
+}
+
+do_compile[noexec] = "1"
+
+do_install() {
+    if [ -n "${TEGRA_AUDIO_DEVICE}" ]; then
+        install -d ${D}${sysconfdir}
+        install -m 0644 ${B}/etc/asound.conf.${TEGRA_AUDIO_DEVICE} ${D}${sysconfdir}/asound.conf
+    fi
+}
+
+ALLOW_EMPTY_${PN} = "1"
+
+FILES_${PN} = "${sysconfdir} ${datadir}/alsa"
+PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/recipes-bsp/tegra-binaries/tegra-configs_21.6.0.bb
+++ b/recipes-bsp/tegra-binaries/tegra-configs_21.6.0.bb
@@ -22,9 +22,6 @@ do_install() {
   # Encoder tuning
   install -m 0644 ${B}/etc/enctune.conf ${D}${sysconfdir}
 
-  # ALSA config (default set in machine configuration file)
-  install -m 0644 ${B}/etc/asound.conf.${ASOUND_CONF_DEFAULT} ${D}${sysconfdir}/asound.conf
-
   # Rule that sets permissions on some of the devices
   install -m 0644 ${B}/etc/udev/rules.d/99-tegra-devices.rules ${D}${sysconfdir}/udev/rules.d
 
@@ -52,13 +49,12 @@ do_install_append_jetson-tk1() {
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 # ${PN}-all is just a utility package
-PACKAGES = "${PN}-all ${PN}-omx-tegra ${PN}-xorg ${PN}-alsa ${PN}-udev ${PN}-nvstartup ${PN}-pulseaudio"
+PACKAGES = "${PN}-all ${PN}-omx-tegra ${PN}-xorg ${PN}-udev ${PN}-nvstartup ${PN}-pulseaudio"
 ALLOW_EMPTY_${PN}-all = "1"
-RDEPENDS_${PN}-all = "${PN}-omx-tegra ${PN}-xorg ${PN}-alsa ${PN}-udev ${PN}-nvstartup ${PN}-pulseaudio"
+RDEPENDS_${PN}-all = "${PN}-omx-tegra ${PN}-xorg ${PN}-udev ${PN}-nvstartup ${PN}-pulseaudio"
 
 FILES_${PN}-omx-tegra = "${sysconfdir}/enctune.conf"
 FILES_${PN}-xorg = "${sysconfdir}/X11"
-FILES_${PN}-alsa = "${sysconfdir}/asound.conf"
 FILES_${PN}-udev = "${sysconfdir}/udev/rules.d/99-tegra-devices.rules ${sysconfdir}/udev/rules.d/99-tegra-mmc-ra.rules"
 FILES_${PN}-pulseaudio = "${sysconfdir}/pulse"
 FILES_${PN}-nvstartup = "${sysconfdir}/init.d/nvstartup ${sbindir}"


### PR DESCRIPTION
Since commit f3c95e88 (alsa-state: update bbappend to use common tegra
override) building alsa-state on TK1 is failling because there is no
tegra-configs-alsa-21.6 package.

Update the TK1 alsa config to also use a tegra-configs-alsa package
like the other tegra platforms.

Signed-off-by: Alban Bedel <alban.bedel@avionic-design.de>