### PR TITLE
Add gl header and pkgconfig files to target SDK

### DIFF
--- a/recipes-graphics/mesa/mesa_%.bbappend
+++ b/recipes-graphics/mesa/mesa_%.bbappend
@@ -48,3 +48,11 @@ PRIVATE_LIBS_${PN}-stubs-dev = "\
     libGLESv2.so.2 \
     libGL.so.1 \
 "
+
+TOOLCHAIN_TARGET_TASK += " \
+    libgles1-mesa-dev \
+    libgles2-mesa-dev \
+    libgles3-mesa-dev \
+    libegl-mesa-dev \
+    libgl-mesa-dev \
+"


### PR DESCRIPTION
This will install gl header files and pkgconfig files to target sdk. This is required during cross compilation of gl rendering applications.

Signed-off-by: Bassem Mohsen <bmohsen@luxoft.com>