### PR TITLE
machine/include/tegra124.conf: Fix the DEFAULTTUNE assignment.

### DIFF
--- a/conf/machine/include/tegra124.inc
+++ b/conf/machine/include/tegra124.inc
@@ -2,10 +2,10 @@
 
 SOC_FAMILY = "tegra124"
 
+DEFAULTTUNE ?= "cortexa15thf-neon-vfpv4"
+
 require conf/machine/include/soc-family.inc
 require conf/machine/include/tune-cortexa15.inc
-
-DEFAULTTUNE = "cortexa15hf-neon"
 
 KERNEL_IMAGETYPE = "zImage"
 


### PR DESCRIPTION
The DEFAULTTUNE assignment is unconditional and misplaced so it always
overrides the settings from the distro or local.conf. Instead it
should use the default value assignment (?=) and be placed before the
include of tune-cortexa15.inc.

Furthermore the value set is suboptimal as the tegra124 SoC support
thumb mode and vfpv4, using "cortexa15thf-neon-vfpv4" enable these two
features in the default settings.

Signed-off-by: Alban Bedel <alban.bedel@avionic-design.de>