### PR TITLE
tegra-binaries: Make sure glibc is used with nvidia libraries

### DIFF
--- a/recipes-bsp/tegra-binaries/gstreamer1.0-plugins-tegra_21.6.0.bb
+++ b/recipes-bsp/tegra-binaries/gstreamer1.0-plugins-tegra_21.6.0.bb
@@ -1,5 +1,5 @@
 require tegra-binaries-${PV}.inc
-require tegra-shared-binaries.inc
+require tegra-shared-libraries.inc
 
 DEPENDS = "\
 	gstreamer1.0-plugins-base \

--- a/recipes-bsp/tegra-binaries/gstreamer1.0-plugins-tegra_21.7.0.bb
+++ b/recipes-bsp/tegra-binaries/gstreamer1.0-plugins-tegra_21.7.0.bb
@@ -1,5 +1,5 @@
 require tegra-binaries-${PV}.inc
-require tegra-shared-binaries.inc
+require tegra-shared-libraries.inc
 
 DEPENDS = "\
 	gstreamer1.0-plugins-base \

--- a/recipes-bsp/tegra-binaries/gstreamer1.0-plugins-tegra_28.2.0.bb
+++ b/recipes-bsp/tegra-binaries/gstreamer1.0-plugins-tegra_28.2.0.bb
@@ -1,5 +1,5 @@
 require tegra-binaries-${PV}.inc
-require tegra-shared-binaries.inc
+require tegra-shared-libraries.inc
 
 DEPENDS = "\
 	gstreamer1.0-plugins-base \

--- a/recipes-bsp/tegra-binaries/gstreamer1.0-plugins-tegra_28.2.1.bb
+++ b/recipes-bsp/tegra-binaries/gstreamer1.0-plugins-tegra_28.2.1.bb
@@ -1,5 +1,5 @@
 require tegra-binaries-${PV}.inc
-require tegra-shared-binaries.inc
+require tegra-shared-libraries.inc
 
 DEPENDS = "\
 	gstreamer1.0-plugins-base \

--- a/recipes-bsp/tegra-binaries/libdrm-nvdc_28.2.0.bb
+++ b/recipes-bsp/tegra-binaries/libdrm-nvdc_28.2.0.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "NVIDIA DRM compatibility library"
 
 require tegra-binaries-${PV}.inc
-require tegra-shared-binaries.inc
+require tegra-shared-libraries.inc
 
 do_configure () {
     tar -C ${B} -x -f ${S}/nv_tegra/nvidia_drivers.tbz2 usr/lib/aarch64-linux-gnu/tegra/libdrm.so.2

--- a/recipes-bsp/tegra-binaries/libdrm-nvdc_28.2.1.bb
+++ b/recipes-bsp/tegra-binaries/libdrm-nvdc_28.2.1.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "NVIDIA DRM compatibility library"
 
 require tegra-binaries-${PV}.inc
-require tegra-shared-binaries.inc
+require tegra-shared-libraries.inc
 
 do_configure () {
     tar -C ${B} -x -f ${S}/nv_tegra/nvidia_drivers.tbz2 usr/lib/aarch64-linux-gnu/tegra/libdrm.so.2

--- a/recipes-bsp/tegra-binaries/tegra-libraries_21.6.0.bb
+++ b/recipes-bsp/tegra-binaries/tegra-libraries_21.6.0.bb
@@ -1,5 +1,5 @@
 require tegra-binaries-${PV}.inc
-require tegra-shared-binaries.inc
+require tegra-shared-libraries.inc
 
 do_configure() {
     tar -C ${B} -x -f ${S}/nv_tegra/nvidia_drivers.tbz2 usr/lib

--- a/recipes-bsp/tegra-binaries/tegra-libraries_21.7.0.bb
+++ b/recipes-bsp/tegra-binaries/tegra-libraries_21.7.0.bb
@@ -1,5 +1,5 @@
 require tegra-binaries-${PV}.inc
-require tegra-shared-binaries.inc
+require tegra-shared-libraries.inc
 
 do_configure() {
     tar -C ${B} -x -f ${S}/nv_tegra/nvidia_drivers.tbz2 usr/lib

--- a/recipes-bsp/tegra-binaries/tegra-libraries_28.2.0.bb
+++ b/recipes-bsp/tegra-binaries/tegra-libraries_28.2.0.bb
@@ -1,5 +1,5 @@
 require tegra-binaries-${PV}.inc
-require tegra-shared-binaries.inc
+require tegra-shared-libraries.inc
 
 inherit update-rc.d systemd
 

--- a/recipes-bsp/tegra-binaries/tegra-libraries_28.2.1.bb
+++ b/recipes-bsp/tegra-binaries/tegra-libraries_28.2.1.bb
@@ -1,5 +1,5 @@
 require tegra-binaries-${PV}.inc
-require tegra-shared-binaries.inc
+require tegra-shared-libraries.inc
 
 inherit update-rc.d systemd
 

--- a/recipes-bsp/tegra-binaries/tegra-shared-libraries.inc
+++ b/recipes-bsp/tegra-binaries/tegra-shared-libraries.inc
@@ -1,0 +1,7 @@
+require tegra-shared-binaries.inc
+
+# The nvidia libraries are linked against glibc so other libc can't be used
+python __anonymous () {
+    if d.getVar('TCLIBC', True) != "glibc":
+        raise bb.parse.SkipPackage("nvidia libraries requires glibc")
+}

--- a/recipes-bsp/tegra-binaries/xserver-xorg-video-nvidia.inc
+++ b/recipes-bsp/tegra-binaries/xserver-xorg-video-nvidia.inc
@@ -1,4 +1,4 @@
-require tegra-shared-binaries.inc
+require tegra-shared-libraries.inc
 
 do_configure() {
     tar -C ${B} -x -f ${S}/nv_tegra/nvidia_drivers.tbz2 usr/lib/xorg ${DRV_EXTRAS}


### PR DESCRIPTION
The libraries provided by nvidia are linked against glibc, so they
can't be used in builds using another libc. To prevent the user from
finding this the hard way add a check for the libc to all the recipes
that install some .so file from nvidia.

Signed-off-by: Alban Bedel <alban.bedel@avionic-design.de>