### PR TITLE
RFS: u-boot-tegra /boot/Image conflict fix

### DIFF
--- a/recipes-bsp/u-boot/u-boot-tegra-common-2016.07.inc
+++ b/recipes-bsp/u-boot/u-boot-tegra-common-2016.07.inc
@@ -30,9 +30,9 @@ UBOOT_EXTLINUX_KERNEL_ARGS_primary = "${KERNEL_ARGS}"
 UBOOT_EXTLINUX_INITRD_primary = "${@'../initrd' if d.getVar('INITRAMFS_IMAGE') != '' and d.getVar('TEGRA_INITRAMFS_INITRD') == '1' else ''}"
 
 do_install_append() {
-	install -m 0644 ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE} ${D}/boot/
-	if [ -n "${INITRAMFS_IMAGE}" -a "${TEGRA_INITRAMFS_INITRD}" = "1" ]; then
-		install -m 0644 ${DEPLOY_DIR_IMAGE}/${INITRAMFS_IMAGE}-${MACHINE}.cpio.gz ${D}/boot/initrd
-	fi
+    install -m 0644 ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE} ${D}/boot/
+    if [ -n "${INITRAMFS_IMAGE}" -a "${TEGRA_INITRAMFS_INITRD}" = "1" ]; then
+        install -m 0644 ${DEPLOY_DIR_IMAGE}/${INITRAMFS_IMAGE}-${MACHINE}.cpio.gz ${D}/boot/initrd
+    fi
 }
 do_install[depends] += "${@'${INITRAMFS_IMAGE}:do_image_complete' if d.getVar('INITRAMFS_IMAGE') != '' and d.getVar('TEGRA_INITRAMFS_INITRD') == '1' else ''}"

--- a/recipes-bsp/u-boot/u-boot-tegra-common-2016.07.inc
+++ b/recipes-bsp/u-boot/u-boot-tegra-common-2016.07.inc
@@ -30,7 +30,6 @@ UBOOT_EXTLINUX_KERNEL_ARGS_primary = "${KERNEL_ARGS}"
 UBOOT_EXTLINUX_INITRD_primary = "${@'../initrd' if d.getVar('INITRAMFS_IMAGE') != '' and d.getVar('TEGRA_INITRAMFS_INITRD') == '1' else ''}"
 
 do_install_append() {
-    install -m 0644 ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE} ${D}/boot/
     if [ -n "${INITRAMFS_IMAGE}" -a "${TEGRA_INITRAMFS_INITRD}" = "1" ]; then
         install -m 0644 ${DEPLOY_DIR_IMAGE}/${INITRAMFS_IMAGE}-${MACHINE}.cpio.gz ${D}/boot/initrd
     fi


### PR DESCRIPTION
RFS: I'm not sure if this is correct, as I don't fully understand why we are installing /boot/Image in the u-boot package. I know that this fixes the build issue I am seeing, but I don't know if it may introduce some other issue. @madisongh could you advise?

Background:
Currently, I'm seeing an RPM conflict between the kernel-image package and the u-boot-tegra package because they both install the (identical) file /boot/Image. Removing the /boot/Image installation in u-boot-tegra fixes the issue.