### PR TITLE
Use wayland with no x11 in distro features

### DIFF
--- a/recipes-graphics/libglvnd/libglvnd/0001-Build-with-x11-or-wayland-egl.patch
+++ b/recipes-graphics/libglvnd/libglvnd/0001-Build-with-x11-or-wayland-egl.patch
@@ -1,0 +1,121 @@
+From a2725c8434a9a23eb9d653d8cc2ddf8c87597fc4 Mon Sep 17 00:00:00 2001
+From: Kurt Kiefer <kurt.kiefer@arthrex.com>
+Date: Fri, 7 Jun 2019 08:27:14 -0700
+Subject: [PATCH] Build with x11 or wayland-egl
+
+---
+ configure.ac              | 20 +++++++++++++++++++-
+ include/EGL/eglplatform.h |  6 ++++++
+ src/EGL/libegl.c          |  8 +++++++-
+ 3 files changed, 32 insertions(+), 2 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 4a2099a..68e4998 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -57,6 +57,14 @@ AC_ARG_ENABLE([glx],
+ )
+ AM_CONDITIONAL([ENABLE_GLX], [test "x$enable_glx" = "xyes"])
+ 
++AC_ARG_ENABLE([wayland],
++    [AS_HELP_STRING([--enable-wayland],
++        [Enable Wayland support @<:@default=disabled@:>@])],
++    [enable_wayland="$enableval"],
++    [enable_wayland=yes]
++)
++AM_CONDITIONAL([ENABLE_WAYLAND], [test "x$enable_wayland" = "xyes"])
++
+ AC_ARG_ENABLE([gles],
+     [AS_HELP_STRING([--disable-gles],
+         [Do not build the libGLES*.so libraries @<:@default=enabled@:>@])],
+@@ -143,9 +151,17 @@ dnl
+ dnl Checks for libraries.
+ AX_PTHREAD()
+ 
++AM_COND_IF([ENABLE_GLX], [
+ PKG_CHECK_MODULES([X11], [x11])
+ PKG_CHECK_MODULES([XEXT], [xext])
+ PKG_CHECK_MODULES([GLPROTO], [glproto])
++AC_DEFINE(WITH_X11,[],[Use X11])
++])
++
++AM_COND_IF([ENABLE_WAYLAND], [
++PKG_CHECK_MODULES([WAYLAND], [wayland-egl])
++AC_DEFINE(WL_EGL_PLATFORM,[],[Use wayland])
++])
+ 
+ dnl Checks for typedefs, structures, and compiler characteristics.
+ AC_C_TYPEOF
+@@ -312,11 +328,13 @@ AC_CONFIG_FILES([Makefile
+                  src/OpenGL/Makefile
+                  src/GLESv1/Makefile
+                  src/GLESv2/Makefile
+-                 src/GLX/Makefile
+                  src/EGL/Makefile
+                  src/GLdispatch/Makefile
+                  src/GLdispatch/vnd-glapi/Makefile
+                  src/util/Makefile
+                  tests/Makefile
+                  tests/dummy/Makefile])
++AM_COND_IF([ENABLE_GLX], [
++AC_CONFIG_FILES([src/GLX/Makefile])
++])
+ AC_OUTPUT
+diff --git a/include/EGL/eglplatform.h b/include/EGL/eglplatform.h
+index 1284089..6ab2529 100644
+--- a/include/EGL/eglplatform.h
++++ b/include/EGL/eglplatform.h
+@@ -83,6 +83,12 @@ typedef int   EGLNativeDisplayType;
+ typedef void *EGLNativeWindowType;
+ typedef void *EGLNativePixmapType;
+ 
++#elif defined(WL_EGL_PLATFORM)
++
++typedef struct wl_display     *EGLNativeDisplayType;
++typedef struct wl_egl_pixmap  *EGLNativePixmapType;
++typedef struct wl_egl_window  *EGLNativeWindowType;
++
+ #elif defined(__ANDROID__) || defined(ANDROID)
+ 
+ #include <android/native_window.h>
+diff --git a/src/EGL/libegl.c b/src/EGL/libegl.c
+index 54e3a28..a2ec660 100644
+--- a/src/EGL/libegl.c
++++ b/src/EGL/libegl.c
+@@ -36,7 +36,9 @@
+ #include <unistd.h>
+ #include <sys/mman.h>
+ 
++#if defined(WITH_X11)
+ #include <X11/Xlib.h>
++#endif
+ 
+ #include "glvnd_pthread.h"
+ #include "libeglabipriv.h"
+@@ -178,6 +180,7 @@ static EGLBoolean IsGbmDisplay(void *native_display)
+ 
+ static EGLBoolean IsX11Display(void *dpy)
+ {
++#if defined(WITH_X11)
+     void *alloc;
+     void *handle;
+     void *XAllocID = NULL;
+@@ -194,6 +197,9 @@ static EGLBoolean IsX11Display(void *dpy)
+     }
+ 
+     return (XAllocID != NULL && XAllocID == alloc);
++#else
++    return EGL_FALSE;
++#endif
+ }
+ 
+ static EGLBoolean IsWaylandDisplay(void *native_display)
+@@ -615,7 +621,7 @@ static EGLBoolean InternalMakeCurrentDispatch(
+ 
+     apiState = __eglCreateAPIState();
+     if (apiState == NULL) {
+-        return False;
++        return EGL_FALSE;
+     }
+ 
+     ret = __glDispatchMakeCurrent(

--- a/recipes-graphics/libglvnd/libglvnd_1.1.1.bb
+++ b/recipes-graphics/libglvnd/libglvnd_1.1.1.bb
@@ -3,17 +3,24 @@ HOMEPAGE = "https://github.com/NVIDIA/libglvnd"
 LICENSE = "MIT & BSD"
 LIC_FILES_CHKSUM = "file://README.md;beginline=309;md5=f98ec0fbe6c0d2fbbd0298b5d9e664d3"
 
-SRC_URI = "https://github.com/NVIDIA/libglvnd/archive/v${PV}.tar.gz;downloadfilename=${BP}.tar.gz"
+SRC_URI = "https://github.com/NVIDIA/libglvnd/archive/v${PV}.tar.gz;downloadfilename=${BP}.tar.gz \
+           file://0001-Build-with-x11-or-wayland-egl.patch \
+           "
 SRC_URI[md5sum] = "390f7934a22a17c9542621b727fc5908"
 SRC_URI[sha256sum] = "baca5e1a78b96a112650cdc597be3f856d4754eb73a7bf3f6629e78a7e9f2b5a"
 
 COMPATIBLE_MACHINE = "(tegra)"
 COMPATIBLE_MACHINE_tegra124 = "(-)"
 
-REQUIRED_DISTRO_FEATURES = "x11 opengl"
-
-DEPENDS = "libx11 libxext xorgproto"
+REQUIRED_DISTRO_FEATURES = "opengl"
 
 inherit autotools pkgconfig
 
 PACKAGE_ARCH_tegra = "${SOC_FAMILY_PKGARCH}"
+
+PACKAGECONFIG ?= "${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'x11', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'wayland', '', d)} \
+"
+
+PACKAGECONFIG[x11] = "--enable-glx,--disable-glx,libx11 libxext xorgproto"
+PACKAGECONFIG[wayland] = "--enable-wayland,--disable-wayland,wayland"

--- a/recipes-graphics/mesa/mesa_%.bbappend
+++ b/recipes-graphics/mesa/mesa_%.bbappend
@@ -37,7 +37,9 @@ move_libraries() {
 do_install_append() {
     if ${@bb.utils.contains("PACKAGECONFIG", "glvnd", "true", "false", d)}; then
         rm -f ${D}${libdir}/libGLESv1_CM.so* ${D}${libdir}/libGLESv2.so*
-	sed -i -e's,lGLX_mesa,lGL,' ${D}${libdir}/pkgconfig/gl.pc
+        if [ -e ${D}${libdir}/pkgconfig/gl.pc ]; then
+	    sed -i -e's,lGLX_mesa,lGL,' ${D}${libdir}/pkgconfig/gl.pc
+        fi
     fi
 }
 


### PR DESCRIPTION
There's not much that needed to change to enable this. There is some minor patching to libglvnd so that it doesn't try to build glx and it has a couple of typedefs that it needs. Then a minor fixup to the mesa bbappend.

I'm sending this PR to warrior since that's where I've tested it (and where I'll be using it), but I've rebased the commits to [master+no_x](/kekiefer/meta-tegra/tree/master+no_x) if you'd rather I submit that. I don't anticipate any problems.