### PR TITLE
kernel-devsrc.bbappend: Use ${bindir}/awk

### DIFF
--- a/recipes-kernel/linux/kernel-devsrc.bbappend
+++ b/recipes-kernel/linux/kernel-devsrc.bbappend
@@ -1,0 +1,7 @@
+do_install_append() {
+    # This fixes the rpm dependency failure on install of kernel-devsrc
+    cd ${D} || true
+    for i in $(grep -srI "!/bin/awk" | cut -d":" -f1); do
+        sed -i -e "s#!/bin/awk#!${bindir}/env awk#g" $i
+    done
+}


### PR DESCRIPTION
Use ${bindir}/awk instead of /bin/awk. This fixes kernel-devsrc
package failure during install.

References:
https://gerrit.automotivelinux.org/gerrit/gitweb?p=AGL/meta-agl.git;a=commit;h=4bfc821810cdee47611c6d3e94d771971f51fa75
https://lists.yoctoproject.org/pipermail/meta-intel/2017-January/004519.html
https://patchwork.openembedded.org/patch/136699/
http://git.yoctoproject.org/cgit/cgit.cgi/yocto-kernel-cache/commit/?h=yocto-4.9&id=d0e0a36eec57f5dfa02045776c69092c145f5000

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>