### PR TITLE
Fix u-boot-fw-utils build for mender support

### DIFF
--- a/recipes-bsp/u-boot/u-boot-common-tegra_2016.07.inc
+++ b/recipes-bsp/u-boot/u-boot-common-tegra_2016.07.inc
@@ -1,3 +1,4 @@
+# This file is shared with fw-utils and u-boot builds
 LICENSE = "GPLv2+"
 DESCRIPTION = "U-Boot for Nvidia Tegra platforms, based on Nvidia sources"
 COMPATIBLE_MACHINE = "(tegra186|tegra210)"
@@ -28,10 +29,3 @@ UBOOT_EXTLINUX_ROOT_primary = "${@uboot_var('cbootargs')} ${KERNEL_ROOTSPEC}"
 UBOOT_EXTLINUX_CONSOLE = ""
 UBOOT_EXTLINUX_KERNEL_ARGS_primary = "${KERNEL_ARGS}"
 UBOOT_EXTLINUX_INITRD_primary = "${@'../initrd' if d.getVar('INITRAMFS_IMAGE') != '' and d.getVar('TEGRA_INITRAMFS_INITRD') == '1' else ''}"
-
-do_install_append() {
-    if [ -n "${INITRAMFS_IMAGE}" -a "${TEGRA_INITRAMFS_INITRD}" = "1" ]; then
-        install -m 0644 ${DEPLOY_DIR_IMAGE}/${INITRAMFS_IMAGE}-${MACHINE}.cpio.gz ${D}/boot/initrd
-    fi
-}
-do_install[depends] += "${@'${INITRAMFS_IMAGE}:do_image_complete' if d.getVar('INITRAMFS_IMAGE') != '' and d.getVar('TEGRA_INITRAMFS_INITRD') == '1' else ''}"

--- a/recipes-bsp/u-boot/u-boot-fw-utils-tegra_2016.07.bb
+++ b/recipes-bsp/u-boot/u-boot-fw-utils-tegra_2016.07.bb
@@ -1,4 +1,4 @@
-require u-boot-tegra-common-${PV}.inc
+require u-boot-common-tegra_${PV}.inc
 
 SUMMARY = "U-Boot bootloader fw_printenv/setenv utilities"
 DEPENDS = "mtd-utils"

--- a/recipes-bsp/u-boot/u-boot-tegra_2016.07.bb
+++ b/recipes-bsp/u-boot/u-boot-tegra_2016.07.bb
@@ -1,7 +1,7 @@
 UBOOT_BINARY ?= "u-boot-dtb.${UBOOT_SUFFIX}"
 
 require recipes-bsp/u-boot/u-boot.inc
-require u-boot-tegra-common-${PV}.inc
+require u-boot-common-tegra_${PV}.inc
 
 PROVIDES += "u-boot"
 DEPENDS += "dtc-native bc-native ${SOC_FAMILY}-flashtools-native tegra-bootfiles nv-tegra-release"
@@ -95,5 +95,12 @@ do_deploy_append_tegra186 () {
         ln -sf ${UBOOT_IMAGE}.bup-payload ${UBOOT_BINARY}.bup-payload
     fi
 }
+
+do_install_append() {
+    if [ -n "${INITRAMFS_IMAGE}" -a "${TEGRA_INITRAMFS_INITRD}" = "1" ]; then
+        install -m 0644 ${DEPLOY_DIR_IMAGE}/${INITRAMFS_IMAGE}-${MACHINE}.cpio.gz ${D}/boot/initrd
+    fi
+}
+do_install[depends] += "${@'${INITRAMFS_IMAGE}:do_image_complete' if d.getVar('INITRAMFS_IMAGE') != '' and d.getVar('TEGRA_INITRAMFS_INITRD') == '1' else ''}"
 
 RPROVIDES_${PN} += "u-boot"


### PR DESCRIPTION
Broken with changes in d377317bfc3bd3e9365602d91e3fdeb5960de07d where
u-boot specific install steps were placed in common file shared with
fw-utils-tegra.  Fix naming of u-boot-common file and add a note that
this is shared with fw-utils.