### PR TITLE
Fix transaction check errors with libvisionworks

### DIFF
--- a/recipes-devtools/visionworks/libvisionworks_1.6.0.500n.bb
+++ b/recipes-devtools/visionworks/libvisionworks_1.6.0.500n.bb
@@ -25,9 +25,10 @@ do_compile() {
 }
 
 do_install() {
-    install -d ${D}${prefix} ${D}${libdir} ${D}${datadir}
+    install -d ${D}${prefix} ${D}${libdir} ${D}${datadir} ${D}${libdir}/pkgconfig
     cp -R --preserve=mode,timestamps ${B}/usr/include ${D}${prefix}/
-    cp -R --preserve=mode,timestamps ${B}/usr/lib/* ${D}${libdir}/
+    cp -R --preserve=mode,timestamps ${B}/usr/lib/pkgconfig/* ${D}${libdir}/pkgconfig
+    cp --preserve=mode,timestamps ${B}/usr/lib/libvisionworks.so ${D}${libdir}/
     cp -R --preserve=mode,timestamps ${B}/usr/share/visionworks ${D}${datadir}/
 }
 


### PR DESCRIPTION
Attempts to build an SDK with -c populate_sdk and with libvisionworks included along with other
packages which use pkgconfig fails with:

> Error: Transaction check error:
  file /usr/lib/pkgconfig from install of libvisionworks-dev-1.6.0.500n-r0.armv8a_tegra186 conflicts with file from package spdlog-dev-1.3.1-r0.aarch64
  file /usr/lib/pkgconfig conflicts between attempted installs of libvisionworks-dev-1.6.0.500n-r0.armv8a_tegra186 and librealsense2-dev-2.13.0-r0.aarch64
  file /usr/lib/pkgconfig conflicts between attempted installs of cuda-command-line-tools-dev-10.0.166+1-r0.armv8a_tegra186 and libvisionworks-dev-1.6.0.500n-r0.armv8a_tegra186

Solution is to use install -d for ${libdir}/pkgconfig instead of cp -R --preserve copy