### PR TITLE
xserver-xorg-video-nvidia: Rename NVIDIA libglx module with the right…

### DIFF
--- a/recipes-bsp/tegra-binaries/xserver-xorg-video-nvidia.inc
+++ b/recipes-bsp/tegra-binaries/xserver-xorg-video-nvidia.inc
@@ -13,7 +13,7 @@ do_install() {
     install -d ${D}${libdir}/xorg/modules/drivers
     install -m 0644 ${DRVROOT}/drivers/nvidia_drv.so ${D}${libdir}/xorg/modules/drivers/
     install -d ${D}${libdir}/xorg/modules/extensions
-    install -m 0644 ${DRVROOT}/extensions/${GLXEXT} ${D}${libdir}/xorg/modules/extensions/
+    install -m 0644 ${DRVROOT}/extensions/${GLXEXT} ${D}${libdir}/xorg/modules/extensions/libglx.so
     if [ -f ${S}/xorg.conf ]; then
         install -d ${D}${datadir}/X11/xorg.conf.d
         install -m 0644 ${S}/xorg.conf ${D}${datadir}/X11/xorg.conf.d/00-tegra-xorg.conf


### PR DESCRIPTION
… name

Fix glx module load error by renaming it with the proper one.

NVIDIA glx module 'libglxserver_nvidia.so' renamed to 'libglx.so'

Before:
(EE) Failed to load module "glx" (module does not exist, 0)

After:
(II) "glx" will be loaded by default.
(II) LoadModule: "extmod"
(II) Module "extmod" already built-in
(II) LoadModule: "glx"
(II) Loading /usr/lib/xorg/modules/extensions/libglx.so
(II) Module glx: vendor="NVIDIA Corporation"
	compiled for 4.0.2, module version = 1.0.0
	Module class: X.Org Server Extension
(II) NVIDIA GLX Module  32.1.0  Release Build  (integ_stage_rel)
     (buildbrain@mobile-u64-2988)  Wed Mar 13 00:25:11 PDT 2019

Signed-off-by: Daniel Gomez <dagmcr@gmail.com>