### PR TITLE
gstreamer1.0-omx-tegra: remove unneeded build-dependency

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-omx-tegra_1.0.0-r32.2.1.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-omx-tegra_1.0.0-r32.2.1.bb
@@ -3,7 +3,7 @@ SECTION = "multimedia"
 LICENSE = "LGPLv2.1"
 LICENSE_FLAGS = "commercial"
 HOMEPAGE = "http://www.gstreamer.net/"
-DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-bad gstreamer1.0-plugins-nveglgles gstreamer1.0-plugins-tegra"
+DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-nveglgles gstreamer1.0-plugins-tegra"
 DEPENDS += "tegra-libraries"
 
 TEGRA_SRC_SUBARCHIVE = "public_sources/gstomx1_src.tbz2"


### PR DESCRIPTION
This removes a significant amount of build dependencies for the image I am building (based on Jetson TX2).