### PR TITLE
egl-wayland: fix for Wayland-only build

### DIFF
--- a/recipes-graphics/libglvnd/libglvnd/0003-Enable-build-without-X11-headers.patch
+++ b/recipes-graphics/libglvnd/libglvnd/0003-Enable-build-without-X11-headers.patch
@@ -1,0 +1,40 @@
+From e3a1f1087efb25d780c638e32c13ebd5de62b065 Mon Sep 17 00:00:00 2001
+From: Kurt Kiefer <kekiefer@gmail.com>
+Date: Tue, 15 Oct 2019 10:41:51 -0700
+Subject: [PATCH] Enable build without X11 headers
+
+---
+ include/EGL/eglplatform.h | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/include/EGL/eglplatform.h b/include/EGL/eglplatform.h
+index 29ab288..e21fc20 100644
+--- a/include/EGL/eglplatform.h
++++ b/include/EGL/eglplatform.h
+@@ -118,6 +118,14 @@ typedef intptr_t EGLNativeWindowType;
+ 
+ #elif defined(__unix__) || defined(USE_X11)
+ 
++#if defined(MESA_EGL_NO_X11_HEADERS)
++
++typedef void            *EGLNativeDisplayType;
++typedef khronos_uintptr_t EGLNativePixmapType;
++typedef khronos_uintptr_t EGLNativeWindowType;
++
++#else
++
+ /* X11 (tentative)  */
+ #include <X11/Xlib.h>
+ #include <X11/Xutil.h>
+@@ -126,6 +134,8 @@ typedef Display *EGLNativeDisplayType;
+ typedef Pixmap   EGLNativePixmapType;
+ typedef Window   EGLNativeWindowType;
+ 
++#endif
++
+ #elif defined(__APPLE__)
+ 
+ typedef int   EGLNativeDisplayType;
+-- 
+2.21.0
+

--- a/recipes-graphics/libglvnd/libglvnd_1.2.0.bb
+++ b/recipes-graphics/libglvnd/libglvnd_1.2.0.bb
@@ -6,6 +6,7 @@ LIC_FILES_CHKSUM = "file://README.md;beginline=310;md5=f98ec0fbe6c0d2fbbd0298b5d
 SRC_URI = "https://github.com/NVIDIA/${BPN}/releases/download/v${PV}/${BP}.tar.gz \
            file://0001-Add-EGL-and-GLES2-extensions-for-Tegra.patch \
            file://0002-Make-Wayland-support-configurable.patch \
+           file://0003-Enable-build-without-X11-headers.patch \
            "
 SRC_URI[md5sum] = "59068b27ff62bf2ad31a028673ab58da"
 SRC_URI[sha256sum] = "2dacbcfa47b7ffb722cbddc0a4f1bc3ecd71d2d7bb461bceb8e396dc6b81dc6d"
@@ -27,3 +28,16 @@ PACKAGECONFIG ?= "${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'x11', '', d)} 
 
 PACKAGECONFIG[x11] = "--enable-x11 --enable-glx,--disable-x11 --disable-glx,libx11 libxext xorgproto"
 PACKAGECONFIG[wayland] = "--enable-wayland,--disable-wayland,wayland"
+
+do_install_append() {
+
+    ## no-X11 hack included from mesa:
+    #because we cannot rely on the fact that all apps will use pkgconfig,
+    #make eglplatform.h independent of MESA_EGL_NO_X11_HEADER
+    sed -i -e 's/^#if defined(MESA_EGL_NO_X11_HEADERS)$/#if defined(MESA_EGL_NO_X11_HEADERS) || ${@bb.utils.contains('PACKAGECONFIG', 'x11', '0', '1', d)}/' ${D}${includedir}/EGL/eglplatform.h
+
+    # If necessary, fix up pkgconfig anyhow, for the benefit of SDK users
+    if ${@bb.utils.contains('PACKAGECONFIG', 'x11', 'false', 'true', d)}; then
+        sed -i -e 's|^Cflags: .*|& -DMESA_EGL_NO_X11_HEADERS|g' ${D}${libdir}/pkgconfig/libglvnd.pc
+    fi
+}


### PR DESCRIPTION
Preprocessor falls through in EGL/eglplatform.h to resolving a couple
typdefs using X11 headers. This works fine when the distro has X11 in
it, but is obviously a problem otherwise.

Make sure we pick up these typedefs using Wayland headers instead,
which are sure to be present.

---

For reference, here is a portion of the error this fixes:
```
| FAILED: src/25a6634@@nvidia-egl-wayland@sha/wayland-eglstream-server.c.o
| aarch64-oe-linux-gcc -march=armv8-a+crc --sysroot=/mnt/act-data/fsl/sources/poky/build-jetson-xavier/tmp/work/aarch64-oe-linux/egl-wayland/1.1.3-r0/recipe-sysroot -Isrc/25a6634@@nvidia-egl-wayland@sha -Isrc -I../git/src -I../git/include -I../git/wayland-egl -Iwayland-eglstream -I/mnt/act-data/fsl/sources/poky/build-jetson-xavier/tmp/work/aarch64-oe-linux/egl-wayland/1.1.3-r0/recipe-sysroot/usr/include/EGL -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -std=gnu99 -Wall -Werror -fvisibility=hidden -DWL_HIDE_DEPRECATED -Wno-pedantic -O2 -g -feliminate-unused-debug-types -fmacro-prefix-map=/mnt/act-data/fsl/sources/poky/build-jetson-xavier/tmp/work/aarch64-oe-linux/egl-wayland/1.1.3-r0=/usr/src/debug/egl-wayland/1.1.3-r0 -fdebug-prefix-map=/mnt/act-data/fsl/sources/poky/build-jetson-xavier/tmp/work/aarch64-oe-linux/egl-wayland/1.1.3-r0=/usr/src/debug/egl-wayland/1.1.3-r0 -fdebug-prefix-map=/mnt/act-data/fsl/sources/poky/build-jetson-xavier/tmp/work/aarch64-oe-linux/egl-wayland/1.1.3-r0/recipe-sysroot= -fdebug-prefix-map=/mnt/act-data/fsl/sources/poky/build-jetson-xavier/tmp/work/aarch64-oe-linux/egl-wayland/1.1.3-r0/recipe-sysroot-native= -fPIC -pthread -MD -MQ 'src/25a6634@@nvidia-egl-wayland@sha/wayland-eglstream-server.c.o' -MF 'src/25a6634@@nvidia-egl-wayland@sha/wayland-eglstream-server.c.o.d' -o 'src/25a6634@@nvidia-egl-wayland@sha/wayland-eglstream-server.c.o' -c ../git/src/wayland-eglstream-server.c
| In file included from /mnt/act-data/fsl/sources/poky/build-jetson-xavier/tmp/work/aarch64-oe-linux/egl-wayland/1.1.3-r0/recipe-sysroot/usr/include/EGL/egl.h:39,
|                  from ../git/src/wayland-eglstream-server.c:35:
| /mnt/act-data/fsl/sources/poky/build-jetson-xavier/tmp/work/aarch64-oe-linux/egl-wayland/1.1.3-r0/recipe-sysroot/usr/include/EGL/eglplatform.h:122:10: fatal error: X11/Xlib.h: No such file or directory
|   122 | #include <X11/Xlib.h>
|       |          ^~~~~~~~~~~~
| compilation terminated.
```