### PR TITLE
gcc-7.3: Fix include files for GCC 7

### DIFF
--- a/contrib/recipes-devtools/gcc/gcc-7.3.inc
+++ b/contrib/recipes-devtools/gcc/gcc-7.3.inc
@@ -1,4 +1,4 @@
-require recipes-devtools/gcc/gcc-common.inc
+require gcc-common.inc
 
 # Third digit in PV should be incremented after a minor release
 

--- a/contrib/recipes-devtools/gcc/gcc-common.inc
+++ b/contrib/recipes-devtools/gcc/gcc-common.inc
@@ -1,0 +1,118 @@
+SUMMARY = "GNU cc and gcc C compilers"
+HOMEPAGE = "http://www.gnu.org/software/gcc/"
+SECTION = "devel"
+LICENSE = "GPL"
+
+NATIVEDEPS = ""
+
+CVE_PRODUCT = "gcc"
+
+inherit autotools gettext texinfo
+
+BPN = "gcc"
+COMPILERDEP = "virtual/${MLPREFIX}${TARGET_PREFIX}gcc:do_gcc_stash_builddir"
+COMPILERDEP_class-nativesdk = "virtual/${TARGET_PREFIX}gcc-crosssdk:do_gcc_stash_builddir"
+
+python extract_stashed_builddir () {
+    src = d.expand("${COMPONENTS_DIR}/${BUILD_ARCH}/gcc-stashed-builddir-${TARGET_SYS}")
+    dest = d.getVar("B")
+    oe.path.copyhardlinktree(src, dest)
+    staging_processfixme([src + "/fixmepath"], dest, dest, dest, d)
+}
+
+def get_gcc_float_setting(bb, d):
+    if d.getVar('ARMPKGSFX_EABI') == "hf" and d.getVar('TRANSLATED_TARGET_ARCH') == "arm":
+        return "--with-float=hard"
+    if d.getVar('TARGET_FPU') in [ 'soft' ]:
+        return "--with-float=soft"
+    if d.getVar('TARGET_FPU') in [ 'ppc-efd' ]:
+        return "--enable-e500_double"
+    return ""
+
+get_gcc_float_setting[vardepvalue] = "${@get_gcc_float_setting(bb, d)}"
+
+def get_gcc_mips_plt_setting(bb, d):
+    if d.getVar('TRANSLATED_TARGET_ARCH') in [ 'mips', 'mipsel' ] and bb.utils.contains('DISTRO_FEATURES', 'mplt', True, False, d):
+        return "--with-mips-plt"
+    return ""
+
+def get_gcc_ppc_plt_settings(bb, d):
+    if d.getVar('TRANSLATED_TARGET_ARCH') in [ 'powerpc' ] and not bb.utils.contains('DISTRO_FEATURES', 'bssplt', True, False, d):
+        return "--enable-secureplt"
+    return ""
+
+def get_long_double_setting(bb, d):
+    if d.getVar('TRANSLATED_TARGET_ARCH') in [ 'powerpc', 'powerpc64' ] and d.getVar('TCLIBC') in [ 'glibc' ]:
+        return "--with-long-double-128"
+    else:
+        return "--without-long-double-128 libgcc_cv_powerpc_float128=no"
+    return ""
+
+def get_gcc_multiarch_setting(bb, d):
+    target_arch = d.getVar('TRANSLATED_TARGET_ARCH')
+    multiarch_options = {
+        "i586":    "--enable-targets=all",
+        "i686":    "--enable-targets=all",
+        "powerpc": "--enable-targets=powerpc64",
+        "mips":    "--enable-targets=all",
+        "sparc":   "--enable-targets=all",
+    }
+
+    if bb.utils.contains('DISTRO_FEATURES', 'multiarch', True, False, d):
+        if target_arch in multiarch_options :
+            return multiarch_options[target_arch]
+    return ""
+
+# this is used by the multilib setup of gcc
+def get_tune_parameters(tune, d):
+    availtunes = d.getVar('AVAILTUNES')
+    if tune not in availtunes.split():
+        bb.error('The tune: %s is not one of the available tunes: %s' % (tune or None, availtunes))
+
+    localdata = bb.data.createCopy(d)
+    override = ':tune-' + tune
+    localdata.setVar('OVERRIDES', localdata.getVar('OVERRIDES', False) + override)
+
+    retdict = {}
+    retdict['tune'] = tune
+    retdict['ccargs'] = localdata.getVar('TUNE_CCARGS')
+    retdict['features'] = localdata.getVar('TUNE_FEATURES')
+    # BASELIB is used by the multilib code to change library paths
+    retdict['baselib'] = localdata.getVar('BASE_LIB') or localdata.getVar('BASELIB')
+    retdict['arch'] = localdata.getVar('TUNE_ARCH')
+    retdict['abiextension'] = localdata.getVar('ABIEXTENSION')
+    retdict['target_fpu'] = localdata.getVar('TARGET_FPU')
+    retdict['pkgarch'] = localdata.getVar('TUNE_PKGARCH')
+    retdict['package_extra_archs'] = localdata.getVar('PACKAGE_EXTRA_ARCHS')
+    return retdict
+
+get_tune_parameters[vardepsexclude] = "AVAILTUNES TUNE_CCARGS OVERRIDES TUNE_FEATURES BASE_LIB BASELIB TUNE_ARCH ABIEXTENSION TARGET_FPU TUNE_PKGARCH PACKAGE_EXTRA_ARCHS"
+
+DEBIANNAME_${MLPREFIX}libgcc = "libgcc1"
+
+MIRRORS =+ "\
+${GNU_MIRROR}/gcc    ftp://gcc.gnu.org/pub/gcc/releases/ \n \
+${GNU_MIRROR}/gcc	ftp://gd.tuwien.ac.at/gnu/gcc/ \n \
+${GNU_MIRROR}/gcc	http://mirrors.rcn.net/pub/sourceware/gcc/releases/ \n \
+${GNU_MIRROR}/gcc   http://gcc.get-software.com/releases/ \n \
+${GNU_MIRROR}/gcc	http://gcc.get-software.com/releases/ \n \
+"
+#
+# Set some default values
+#
+gcclibdir = "${libdir}/gcc"
+BINV = "${PV}"
+#S = "${WORKDIR}/gcc-${PV}"
+S = "${TMPDIR}/work-shared/gcc-${PV}-${PR}/gcc-${PV}"
+
+B = "${WORKDIR}/gcc-${PV}/build.${HOST_SYS}.${TARGET_SYS}"
+
+target_includedir ?= "${includedir}"
+target_libdir ?= "${libdir}"
+target_base_libdir ?= "${base_libdir}"
+target_prefix ?= "${prefix}"
+
+# We need to ensure that for the shared work directory, the do_patch signatures match
+# The real WORKDIR location isn't a dependency for the shared workdir.
+src_patches[vardepsexclude] = "WORKDIR"
+should_apply[vardepsexclude] += "PN"

--- a/contrib/recipes-devtools/gcc/gcc-configure-common.inc
+++ b/contrib/recipes-devtools/gcc/gcc-configure-common.inc
@@ -1,0 +1,126 @@
+require gcc-multilib-config.inc
+require gcc-shared-source.inc
+#
+# Build the list of lanaguages to build.
+#
+# These can be overridden by the version specific .inc file.
+
+# Java (gcj doesn't work on all architectures)
+JAVA ?= ",java"
+JAVA_arm ?= ""
+JAVA_armeb ?= ""
+JAVA_mipsel ?= ""
+JAVA_sh3 ?= ""
+# gcc 3.x expects 'f77', 4.0 expects 'f95', 4.1 and 4.2 expect 'fortran'
+FORTRAN ?= ",f77"
+LANGUAGES ?= "c,c++${FORTRAN}${JAVA}"
+
+EXTRA_OECONF_BASE ?= ""
+EXTRA_OECONF_PATHS ?= ""
+
+GCCMULTILIB ?= "--disable-multilib"
+GCCTHREADS ?= "posix"
+
+GCCPIE ??= ""
+
+EXTRA_OECONF = "\
+    ${@['--enable-clocale=generic', ''][d.getVar('USE_NLS') != 'no']} \
+    --with-gnu-ld \
+    --enable-shared \
+    --enable-languages=${LANGUAGES} \
+    --enable-threads=${GCCTHREADS} \
+    ${GCCMULTILIB} \
+    ${GCCPIE} \
+    --enable-c99 \
+    --enable-long-long \
+    --enable-symvers=gnu \
+    --enable-libstdcxx-pch \
+    --program-prefix=${TARGET_PREFIX} \
+    --without-local-prefix \
+    ${EXTRA_OECONF_BASE} \
+    ${EXTRA_OECONF_GCC_FLOAT} \
+    ${EXTRA_OECONF_PATHS} \
+    ${@get_gcc_mips_plt_setting(bb, d)} \
+    ${@get_gcc_ppc_plt_settings(bb, d)} \
+    ${@get_long_double_setting(bb, d)} \
+    ${@get_gcc_multiarch_setting(bb, d)} \
+"
+
+# glibc version is a minimum controlling whether features are enabled. 
+# Doesn't need to track glibc exactly
+EXTRA_OECONF_append_libc-glibc = " --with-glibc-version=2.28 "
+
+# Set this here since GCC configure won't auto-detect and enable
+# initfini-arry when cross compiling.
+EXTRA_OECONF_append = " --enable-initfini-array"
+
+export gcc_cv_collect2_libs = 'none required'
+# We need to set gcc_cv_collect2_libs else there is cross-compilation badness
+# in the config.log files (which might not get generated until do_compile
+# hence being missed by the insane do_configure check).
+
+EXTRA_OECONF_append_linux = " --enable-__cxa_atexit"
+
+EXTRA_OECONF_append_mips64 = " --with-abi=64 --with-arch-64=mips64 --with-tune-64=mips64"
+EXTRA_OECONF_append_mips64el = " --with-abi=64 --with-arch-64=mips64 --with-tune-64=mips64"
+EXTRA_OECONF_append_mips64n32 = " --with-abi=64 --with-arch-64=mips64 --with-tune-64=mips64"
+EXTRA_OECONF_append_mips64eln32 = " --with-abi=64 --with-arch-64=mips64 --with-tune-64=mips64"
+EXTRA_OECONF_append_mipsisa32r6el = " --with-abi=32 --with-arch=mips32r6"
+EXTRA_OECONF_append_mipsisa32r6 = " --with-abi=32 --with-arch=mips32r6"
+EXTRA_OECONF_append_mipsisa64r6el = " --with-abi=64 --with-arch-64=mips64r6"
+EXTRA_OECONF_append_mipsisa64r6 = " --with-abi=64 --with-arch-64=mips64r6"
+
+EXTRA_OECONF_GCC_FLOAT ??= ""
+CPPFLAGS = ""
+
+SYSTEMHEADERS = "${target_includedir}"
+SYSTEMLIBS = "${target_base_libdir}/"
+SYSTEMLIBS1 = "${target_libdir}/"
+
+do_configure_prepend () {
+	# teach gcc to find correct target includedir when checking libc ssp support
+	mkdir -p ${B}/gcc
+	echo "NATIVE_SYSTEM_HEADER_DIR = ${SYSTEMHEADERS}" > ${B}/gcc/t-oe
+	cat ${S}/gcc/defaults.h | grep -v "\#endif.*GCC_DEFAULTS_H" > ${B}/gcc/defaults.h.new
+	cat >>${B}/gcc/defaults.h.new <<_EOF
+#define NATIVE_SYSTEM_HEADER_DIR "${SYSTEMHEADERS}"
+#define STANDARD_STARTFILE_PREFIX_1 "${SYSTEMLIBS}"
+#define STANDARD_STARTFILE_PREFIX_2 "${SYSTEMLIBS1}"
+#define SYSTEMLIBS_DIR "${SYSTEMLIBS}"
+#endif /* ! GCC_DEFAULTS_H */
+_EOF
+	mv ${B}/gcc/defaults.h.new ${B}/gcc/defaults.h
+}
+
+do_configure () {
+	# Setup these vars for cross building only
+	# ... because foo_FOR_TARGET apparently gets misinterpreted inside the
+	# gcc build stuff when the build is producing a cross compiler - i.e.
+	# when the 'current' target is the 'host' system, and the host is not
+	# the target (because the build is actually making a cross compiler!)
+	if [ "${BUILD_SYS}" != "${HOST_SYS}" ]; then
+		export CC_FOR_TARGET="${CC}"
+		export GCC_FOR_TARGET="${CC}"
+		export CXX_FOR_TARGET="${CXX}"
+		export AS_FOR_TARGET="${HOST_PREFIX}as"
+		export LD_FOR_TARGET="${HOST_PREFIX}ld"
+		export NM_FOR_TARGET="${HOST_PREFIX}nm"
+		export AR_FOR_TARGET="${HOST_PREFIX}ar"
+		export GFORTRAN_FOR_TARGET="gfortran"
+		export RANLIB_FOR_TARGET="${HOST_PREFIX}ranlib"
+	fi
+	export CC_FOR_BUILD="${BUILD_CC}"
+	export CXX_FOR_BUILD="${BUILD_CXX}"
+	export CFLAGS_FOR_BUILD="${BUILD_CFLAGS}"
+	export CPPFLAGS_FOR_BUILD="${BUILD_CPPFLAGS}"
+	export CXXFLAGS_FOR_BUILD="${BUILD_CXXFLAGS}"
+	export LDFLAGS_FOR_BUILD="${BUILD_LDFLAGS}"
+	export CFLAGS_FOR_TARGET="${TARGET_CFLAGS}"
+	export CPPFLAGS_FOR_TARGET="${TARGET_CPPFLAGS}"
+	export CXXFLAGS_FOR_TARGET="${TARGET_CXXFLAGS}"
+	export LDFLAGS_FOR_TARGET="${TARGET_LDFLAGS}"
+
+
+	oe_runconf
+}
+

--- a/contrib/recipes-devtools/gcc/gcc-cross-canadian.inc
+++ b/contrib/recipes-devtools/gcc/gcc-cross-canadian.inc
@@ -1,0 +1,168 @@
+inherit cross-canadian
+
+SUMMARY = "GNU cc and gcc C compilers (cross-canadian for ${TARGET_ARCH} target)"
+PN = "gcc-cross-canadian-${TRANSLATED_TARGET_ARCH}"
+
+DEPENDS = "virtual/${TARGET_PREFIX}gcc virtual/${HOST_PREFIX}gcc-crosssdk virtual/${HOST_PREFIX}binutils-crosssdk virtual/nativesdk-libc nativesdk-gettext flex-native virtual/libc"
+
+GCCMULTILIB = "--enable-multilib"
+
+require gcc-configure-common.inc
+
+EXTRA_OECONF_PATHS = "\
+    --with-gxx-include-dir=/not/exist${target_includedir}/c++/${BINV} \
+    --with-build-time-tools=${STAGING_DIR_NATIVE}${prefix_native}/${TARGET_SYS}/bin \
+    --with-sysroot=/not/exist \
+    --with-build-sysroot=${STAGING_DIR_TARGET} \
+"
+# We have to point gcc at a sysroot but we don't need to rebuild if this changes
+# e.g. we switch between different machines with different tunes.
+EXTRA_OECONF_PATHS[vardepsexclude] = "TUNE_PKGARCH"
+TARGET_ARCH[vardepsexclude] = "TUNE_ARCH"
+get_gcc_float_setting[vardepvalue] = ""
+
+#
+# gcc-cross looks and finds these in ${exec_prefix} but we're not so lucky
+# for the sdk. Hardcoding the paths ensures the build doesn't go canadian or worse.
+#
+export AR_FOR_TARGET = "${TARGET_PREFIX}ar"
+export AS_FOR_TARGET = "${TARGET_PREFIX}as"
+export DLLTOOL_FOR_TARGET = "${TARGET_PREFIX}dlltool"
+export CC_FOR_TARGET = "${TARGET_PREFIX}gcc"
+export CXX_FOR_TARGET = "${TARGET_PREFIX}g++"
+export GCC_FOR_TARGET = "${TARGET_PREFIX}gcc"
+export LD_FOR_TARGET = "${TARGET_PREFIX}ld"
+export LIPO_FOR_TARGET = "${TARGET_PREFIX}lipo"
+export NM_FOR_TARGET = "${TARGET_PREFIX}nm"
+export OBJDUMP_FOR_TARGET = "${TARGET_PREFIX}objdump"
+export RANLIB_FOR_TARGET = "${TARGET_PREFIX}ranlib"
+export STRIP_FOR_TARGET = "${TARGET_PREFIX}strip"
+export WINDRES_FOR_TARGET = "${TARGET_PREFIX}windres"
+
+#
+# We need to override this and make sure the compiler can find staging
+#
+export ARCH_FLAGS_FOR_TARGET = "--sysroot=${STAGING_DIR_TARGET}"
+
+do_configure () {
+	export CC_FOR_BUILD="${BUILD_CC}"
+	export CXX_FOR_BUILD="${BUILD_CXX}"
+	export CFLAGS_FOR_BUILD="${BUILD_CFLAGS}"
+	export CPPFLAGS_FOR_BUILD="${BUILD_CPPFLAGS}"
+	export CXXFLAGS_FOR_BUILD="${BUILD_CXXFLAGS}"
+	export LDFLAGS_FOR_BUILD="${BUILD_LDFLAGS}"
+	export CFLAGS_FOR_TARGET="${TARGET_CFLAGS}"
+	export CPPFLAGS_FOR_TARGET="${TARGET_CPPFLAGS}"
+	export CXXFLAGS_FOR_TARGET="${TARGET_CXXFLAGS}"
+	export LDFLAGS_FOR_TARGET="${TARGET_LDFLAGS}"
+	oe_runconf
+}
+
+do_compile () {
+	oe_runmake all-host configure-target-libgcc
+	(cd ${B}/${TARGET_SYS}/libgcc; oe_runmake enable-execute-stack.c unwind.h md-unwind-support.h sfp-machine.h gthr-default.h)
+}
+
+# Having anything auto depending on gcc-cross-sdk is a really bad idea...
+EXCLUDE_FROM_SHLIBS = "1"
+
+PACKAGES = "${PN}-dbg ${PN} ${PN}-doc"
+
+FILES_${PN} = "\
+    ${exec_prefix}/bin/* \
+    ${libexecdir}/gcc/${TARGET_SYS}/${BINV}/* \
+    ${gcclibdir}/${TARGET_SYS}/${BINV}/*.o \
+    ${gcclibdir}/${TARGET_SYS}/${BINV}/specs \
+    ${gcclibdir}/${TARGET_SYS}/${BINV}/lib* \
+    ${gcclibdir}/${TARGET_SYS}/${BINV}/include \
+    ${gcclibdir}/${TARGET_SYS}/${BINV}/include-fixed \
+    ${gcclibdir}/${TARGET_SYS}/${BINV}/plugin/include/ \
+    ${gcclibdir}/${TARGET_SYS}/${BINV}/plugin/gtype.* \
+    ${includedir}/c++/${BINV} \
+    ${prefix}/${TARGET_SYS}/bin/* \
+    ${prefix}/${TARGET_SYS}/lib/* \
+    ${prefix}/${TARGET_SYS}${target_includedir}/* \
+"
+INSANE_SKIP_${PN} += "dev-so"
+
+FILES_${PN}-doc = "\
+    ${infodir} \
+    ${mandir} \
+    ${gcclibdir}/${TARGET_SYS}/${BINV}/include/README \
+"
+
+EXEEXT = ""
+
+# Compute how to get from libexecdir to bindir in python (easier than shell)
+BINRELPATH = "${@os.path.relpath(d.expand("${bindir}"), d.expand("${libexecdir}/gcc/${TARGET_SYS}/${BINV}"))}"
+
+do_install () {
+	( cd ${B}/${TARGET_SYS}/libgcc; oe_runmake 'DESTDIR=${D}' install-unwind_h-forbuild install-unwind_h )
+	oe_runmake 'DESTDIR=${D}' install-host
+
+	# Cleanup some of the ${libdir}{,exec}/gcc stuff ...
+	rm -r ${D}${libdir}/gcc/${TARGET_SYS}/${BINV}/install-tools
+	rm -r ${D}${libexecdir}/gcc/${TARGET_SYS}/${BINV}/install-tools
+	rm -rf ${D}${libdir}/gcc/${TARGET_SYS}/${BINV}/finclude
+
+	# We care about g++ not c++
+	rm -f ${D}${bindir}/*c++
+
+	# We don't care about the gcc-<version> copies
+	rm -f ${D}${bindir}/*gcc-?.?*
+
+	# We use libiberty from binutils
+	rm -f ${D}${prefix}/${TARGET_SYS}/lib/libiberty.a
+	# Not sure where the strange paths come from
+	rm -f ${D}${libdir}/../lib/libiberty.a
+	rm -f ${D}${libdir}/libiberty.a
+
+	# Cleanup empty directories which are not shipped
+	# we use rmdir instead of 'rm -f' to ensure the non empty directories are not deleted
+	# ${D}${libdir}/../lib only seems to appear with SDKMACHINE=i686
+	local empty_dirs="${D}${libdir}/../lib ${D}${prefix}/${TARGET_SYS}/lib ${D}${prefix}/${TARGET_SYS} ${D}${includedir}"
+	for i in $empty_dirs; do
+		[ -d $i ] && rmdir --ignore-fail-on-non-empty $i
+	done
+
+	# Insert symlinks into libexec so when tools without a prefix are searched for, the correct ones are
+	# found.
+	dest=${D}${libexecdir}/gcc/${TARGET_SYS}/${BINV}/
+	install -d $dest
+	suffix=${EXEEXT}
+	for t in ar as ld nm objcopy objdump ranlib strip g77 gcc cpp gfortran; do
+		if [ "$t" = "g77" -o "$t" = "gfortran" ] && [ ! -e ${D}${bindir}/${TARGET_PREFIX}$t$suffix ]; then
+			continue
+		fi
+
+		ln -sf ${BINRELPATH}/${TARGET_PREFIX}$t$suffix $dest$t$suffix
+	done
+	t=real-ld
+	ln -sf ${BINRELPATH}/${TARGET_PREFIX}ld$suffix $dest$t$suffix
+
+	# libquadmath headers need to  be available in the gcc libexec dir
+	install -d ${D}${libdir}/gcc/${TARGET_SYS}/${BINV}/include/
+	cp ${S}/libquadmath/quadmath.h ${D}${libdir}/gcc/${TARGET_SYS}/${BINV}/include/
+	cp ${S}/libquadmath/quadmath_weak.h ${D}${libdir}/gcc/${TARGET_SYS}/${BINV}/include/
+
+	chown -R root:root ${D}
+	
+	cross_canadian_bindirlinks
+}
+
+ELFUTILS = "nativesdk-elfutils"
+DEPENDS += "nativesdk-gmp nativesdk-mpfr nativesdk-libmpc ${ELFUTILS} nativesdk-zlib"
+RDEPENDS_${PN} += "nativesdk-mpfr nativesdk-libmpc ${ELFUTILS}"
+
+SYSTEMHEADERS = "${target_includedir}/"
+SYSTEMLIBS = "${target_base_libdir}/"
+SYSTEMLIBS1 = "${target_libdir}/"
+
+EXTRA_OECONF += "--enable-poison-system-directories"
+
+EXTRA_OECONF_append_libc-baremetal = " --without-headers"
+EXTRA_OECONF_remove_libc-baremetal = "--with-sysroot=/not/exist"
+EXTRA_OECONF_remove_libc-baremetal = "--with-build-sysroot=${STAGING_DIR_TARGET}"
+
+# gcc 4.7 needs -isystem
+export ARCH_FLAGS_FOR_TARGET = "--sysroot=${STAGING_DIR_TARGET} -isystem=${target_includedir}"

--- a/contrib/recipes-devtools/gcc/gcc-cross-canadian_7.3.bb
+++ b/contrib/recipes-devtools/gcc/gcc-cross-canadian_7.3.bb
@@ -1,5 +1,5 @@
 require recipes-devtools/gcc/gcc-${PV}.inc
-require recipes-devtools/gcc/gcc-cross-canadian.inc
+require gcc-cross-canadian.inc
 
 
 

--- a/contrib/recipes-devtools/gcc/gcc-cross.inc
+++ b/contrib/recipes-devtools/gcc/gcc-cross.inc
@@ -1,0 +1,222 @@
+inherit cross
+
+INHIBIT_DEFAULT_DEPS = "1"
+EXTRADEPENDS = ""
+DEPENDS = "virtual/${TARGET_PREFIX}binutils ${EXTRADEPENDS} ${NATIVEDEPS}"
+PROVIDES = "virtual/${TARGET_PREFIX}gcc virtual/${TARGET_PREFIX}g++"
+python () {
+    if d.getVar("TARGET_OS").startswith("linux"):
+        d.setVar("EXTRADEPENDS", "linux-libc-headers")
+}
+
+PN = "gcc-cross-${TARGET_ARCH}"
+
+# Ignore how TARGET_ARCH is computed.
+TARGET_ARCH[vardepvalue] = "${TARGET_ARCH}"
+
+require gcc-configure-common.inc
+
+# While we want the 'gnu' hash style, we explicitly set it to sysv here to
+# ensure that any recipe which doesn't obey our LDFLAGS (which also set it to
+# gnu) will hit a QA failure.
+LINKER_HASH_STYLE ?= "sysv"
+
+EXTRA_OECONF += "--enable-poison-system-directories"
+EXTRA_OECONF_append_sh4 = " \
+    --with-multilib-list= \
+    --enable-incomplete-targets \
+"
+
+EXTRA_OECONF += "\
+    --with-system-zlib \
+"
+
+EXTRA_OECONF_append_libc-baremetal = " --without-headers"
+EXTRA_OECONF_remove_libc-baremetal = "--enable-threads=posix"
+EXTRA_OECONF_remove_libc-newlib = "--enable-threads=posix"
+
+EXTRA_OECONF_PATHS = "\
+    --with-gxx-include-dir=/not/exist${target_includedir}/c++/${BINV} \
+    --with-sysroot=/not/exist \
+    --with-build-sysroot=${STAGING_DIR_TARGET} \
+"
+
+ARCH_FLAGS_FOR_TARGET += "-isystem${STAGING_DIR_TARGET}${target_includedir}"
+
+do_configure_prepend () {
+	install -d ${RECIPE_SYSROOT}${target_includedir}
+	touch ${RECIPE_SYSROOT}${target_includedir}/limits.h
+}
+
+do_compile () {
+	export CC="${BUILD_CC}"
+	export AR_FOR_TARGET="${TARGET_SYS}-ar"
+	export RANLIB_FOR_TARGET="${TARGET_SYS}-ranlib"
+	export LD_FOR_TARGET="${TARGET_SYS}-ld"
+	export NM_FOR_TARGET="${TARGET_SYS}-nm"
+	export CC_FOR_TARGET="${CCACHE} ${TARGET_SYS}-gcc"
+	export CFLAGS_FOR_TARGET="${TARGET_CFLAGS}"
+	export CPPFLAGS_FOR_TARGET="${TARGET_CPPFLAGS}"
+	export CXXFLAGS_FOR_TARGET="${TARGET_CXXFLAGS}"
+	export LDFLAGS_FOR_TARGET="${TARGET_LDFLAGS}"
+
+	oe_runmake all-host configure-target-libgcc
+	(cd ${B}/${TARGET_SYS}/libgcc; oe_runmake enable-execute-stack.c unwind.h md-unwind-support.h sfp-machine.h gthr-default.h)
+	# now generate script to drive testing
+	echo "#!/usr/bin/env sh" >${B}/${TARGET_PREFIX}testgcc
+	set >> ${B}/${TARGET_PREFIX}testgcc
+	# prune out the unneeded vars
+	sed -i -e "/^BASH/d" ${B}/${TARGET_PREFIX}testgcc
+	sed -i -e "/^USER/d" ${B}/${TARGET_PREFIX}testgcc
+	sed -i -e "/^OPT/d" ${B}/${TARGET_PREFIX}testgcc
+	sed -i -e "/^DIRSTACK/d" ${B}/${TARGET_PREFIX}testgcc
+	sed -i -e "/^EUID/d" ${B}/${TARGET_PREFIX}testgcc
+	sed -i -e "/^FUNCNAME/d" ${B}/${TARGET_PREFIX}testgcc
+	sed -i -e "/^GROUPS/d" ${B}/${TARGET_PREFIX}testgcc
+	sed -i -e "/^HOST/d" ${B}/${TARGET_PREFIX}testgcc
+	sed -i -e "/^HOME/d" ${B}/${TARGET_PREFIX}testgcc
+	sed -i -e "/^IFS/d" ${B}/${TARGET_PREFIX}testgcc
+	sed -i -e "/^LC_ALL/d" ${B}/${TARGET_PREFIX}testgcc
+	sed -i -e "/^LOGNAME/d" ${B}/${TARGET_PREFIX}testgcc
+	sed -i -e "/^MACHTYPE/d" ${B}/${TARGET_PREFIX}testgcc
+	sed -i -e "/^OSTYPE/d" ${B}/${TARGET_PREFIX}testgcc
+	sed -i -e "/^PIPE/d" ${B}/${TARGET_PREFIX}testgcc
+	sed -i -e "/^SHELL/d" ${B}/${TARGET_PREFIX}testgcc
+	sed -i -e "/^'/d" ${B}/${TARGET_PREFIX}testgcc
+	sed -i -e "/^UID/d" ${B}/${TARGET_PREFIX}testgcc
+	sed -i -e "/^TERM/d" ${B}/${TARGET_PREFIX}testgcc
+	sed -i -e "/^PKG_/d" ${B}/${TARGET_PREFIX}testgcc
+	sed -i -e "/^POSIXLY_/d" ${B}/${TARGET_PREFIX}testgcc
+	sed -i -e "/^PPID/d" ${B}/${TARGET_PREFIX}testgcc
+	sed -i -e "/^PS4/d" ${B}/${TARGET_PREFIX}testgcc
+	sed -i -e "/^Q/d" ${B}/${TARGET_PREFIX}testgcc
+	sed -i -e "/^SHLVL/d" ${B}/${TARGET_PREFIX}testgcc
+	sed -i -e "/^STAGING/d" ${B}/${TARGET_PREFIX}testgcc
+	sed -i -e "/^LD_LIBRARY_PATH/d" ${B}/${TARGET_PREFIX}testgcc
+	sed -i -e "/^PSEUDO/d" ${B}/${TARGET_PREFIX}testgcc
+
+	# append execution part of the script
+cat >> ${B}/${TARGET_PREFIX}testgcc << STOP
+target="\$1"
+usage () {
+	echo "Usage:"
+	echo "\$0 user@target 'extra options to dejagnu'"
+	echo "\$0 target 'extra options to dejagnu'"
+	echo "\$0 target"
+	echo "e.g. \$0 192.168.7.2 ' dg.exp=visibility-d.c'"
+	echo "will only run visibility-d.c test case"
+	echo "e.g. \$0 192.168.7.2 '/-mthumb dg.exp=visibility-d.c'"
+	echo "will only run visibility-d.c test case in thumb mode"
+	echo "You need to have dejagnu autogen expect installed"
+	echo "on the build host"
+    }
+if [ "x\$target" = "x" ]
+then
+	echo "Please specify the target machine and remote user in form of user@target\n"
+	usage
+	exit 1;
+fi
+
+shift
+
+echo "\$target" | grep "@" 2>&1 > /dev/null
+if [ "x\$?" = "x0" ]
+then
+   user=\$(echo \$target | cut -d '@' -f 1)
+   target=\$(echo \$target | cut -d '@' -f 2)
+else
+   user=\$USER
+fi
+ssh \$user@\$target date 2>&1 > /dev/null
+if [ "x\$?" != "x0" ]
+then
+	echo "Failed connecting to \$user@\$target it could be because"
+	echo "you don't have passwordless ssh setup to access \$target"
+	echo "or sometimes host key has been changed"
+	echo "in such case do something like below on build host"
+	echo "ssh-keygen -f "~/.ssh/known_hosts" -R \$target"
+	echo "and then try ssh \$user@\$target"
+
+	usage
+	exit 1
+fi
+	echo "lappend boards_dir [pwd]/../../.." > ${B}/site.exp
+	echo "load_generic_config \"unix\"" > ${B}/${PACKAGE_ARCH}.exp
+	echo "set_board_info username \$user" >> ${B}/${PACKAGE_ARCH}.exp
+	echo "set_board_info rsh_prog ssh" >> ${B}/${PACKAGE_ARCH}.exp
+	echo "set_board_info rcp_prog scp" >> ${B}/${PACKAGE_ARCH}.exp
+	echo "set_board_info hostname \$target" >> ${B}/${PACKAGE_ARCH}.exp
+	DEJAGNU=${B}/site.exp make -k check RUNTESTFLAGS="--target_board=${PACKAGE_ARCH}\$@"
+
+STOP
+
+	chmod +x ${B}/${TARGET_PREFIX}testgcc
+
+}
+
+INHIBIT_PACKAGE_STRIP = "1"
+
+# Compute how to get from libexecdir to bindir in python (easier than shell)
+BINRELPATH = "${@os.path.relpath(d.expand("${STAGING_DIR_NATIVE}${prefix_native}/bin/${TARGET_SYS}"), d.expand("${libexecdir}/gcc/${TARGET_SYS}/${BINV}"))}"
+
+do_install () {
+	( cd ${B}/${TARGET_SYS}/libgcc; oe_runmake 'DESTDIR=${D}' install-unwind_h-forbuild install-unwind_h )
+	oe_runmake 'DESTDIR=${D}' install-host
+
+	install -d ${D}${target_base_libdir}
+	install -d ${D}${target_libdir}
+
+	# Link gfortran to g77 to satisfy not-so-smart configure or hard coded g77
+	# gfortran is fully backwards compatible. This is a safe and practical solution. 
+	if [ -n "${@d.getVar('FORTRAN')}" ]; then
+		ln -sf ${STAGING_DIR_NATIVE}${prefix_native}/bin/${TARGET_PREFIX}gfortran ${STAGING_DIR_NATIVE}${prefix_native}/bin/${TARGET_PREFIX}g77 || true
+		fortsymlinks="g77 gfortran"
+	fi
+
+	# Insert symlinks into libexec so when tools without a prefix are searched for, the correct ones are
+	# found. These need to be relative paths so they work in different locations.
+	dest=${D}${libexecdir}/gcc/${TARGET_SYS}/${BINV}/
+	install -d $dest
+	for t in ar as ld ld.bfd ld.gold nm objcopy objdump ranlib strip gcc cpp $fortsymlinks; do
+		ln -sf ${BINRELPATH}/${TARGET_PREFIX}$t $dest$t
+		ln -sf ${BINRELPATH}/${TARGET_PREFIX}$t ${dest}${TARGET_PREFIX}$t
+	done
+
+	# Remove things we don't need but keep share/java
+	for d in info man share/doc share/locale share/man share/info; do
+		rm -rf ${D}${STAGING_DIR_NATIVE}${prefix_native}/$d
+	done
+
+	# libquadmath headers need to  be available in the gcc libexec dir
+	install -d ${D}${libdir}/gcc/${TARGET_SYS}/${BINV}/include/
+	cp ${S}/libquadmath/quadmath.h ${D}${libdir}/gcc/${TARGET_SYS}/${BINV}/include/
+	cp ${S}/libquadmath/quadmath_weak.h ${D}${libdir}/gcc/${TARGET_SYS}/${BINV}/include/
+
+	# We use libiberty from binutils
+	find ${D}${exec_prefix}/lib -name libiberty.a | xargs rm -f
+	find ${D}${exec_prefix}/lib -name libiberty.h | xargs rm -f
+}
+
+do_package[noexec] = "1"
+do_packagedata[noexec] = "1"
+do_package_write_ipk[noexec] = "1"
+do_package_write_rpm[noexec] = "1"
+do_package_write_deb[noexec] = "1"
+
+BUILDDIRSTASH = "${WORKDIR}/stashed-builddir"
+do_gcc_stash_builddir[dirs] = "${B}"
+do_gcc_stash_builddir[cleandirs] = "${BUILDDIRSTASH}"
+do_gcc_stash_builddir () {
+	dest=${BUILDDIRSTASH}
+	hardlinkdir . $dest
+}
+addtask do_gcc_stash_builddir after do_compile before do_install
+SSTATETASKS += "do_gcc_stash_builddir"
+do_gcc_stash_builddir[sstate-inputdirs] = "${BUILDDIRSTASH}"
+do_gcc_stash_builddir[sstate-outputdirs] = "${COMPONENTS_DIR}/${BUILD_ARCH}/gcc-stashed-builddir-${TARGET_SYS}"
+do_gcc_stash_builddir[sstate-fixmedir] = "${COMPONENTS_DIR}/${BUILD_ARCH}/gcc-stashed-builddir-${TARGET_SYS}"
+
+python do_gcc_stash_builddir_setscene () {
+    sstate_setscene(d)
+}
+addtask do_gcc_stash_builddir_setscene

--- a/contrib/recipes-devtools/gcc/gcc-cross_7.3.bb
+++ b/contrib/recipes-devtools/gcc/gcc-cross_7.3.bb
@@ -1,3 +1,3 @@
 require recipes-devtools/gcc/gcc-${PV}.inc
-require recipes-devtools/gcc/gcc-cross.inc
+require gcc-cross.inc
 

--- a/contrib/recipes-devtools/gcc/gcc-crosssdk.inc
+++ b/contrib/recipes-devtools/gcc/gcc-crosssdk.inc
@@ -1,0 +1,12 @@
+inherit crosssdk
+
+PN = "gcc-crosssdk-${SDK_SYS}"
+
+SYSTEMHEADERS = "${SDKPATHNATIVE}${prefix_nativesdk}/include"
+SYSTEMLIBS = "${SDKPATHNATIVE}${base_libdir_nativesdk}/"
+SYSTEMLIBS1 = "${SDKPATHNATIVE}${libdir_nativesdk}/"
+
+GCCMULTILIB = "--disable-multilib"
+
+DEPENDS = "virtual/${TARGET_PREFIX}binutils-crosssdk gettext-native ${NATIVEDEPS}"
+PROVIDES = "virtual/${TARGET_PREFIX}gcc-crosssdk virtual/${TARGET_PREFIX}g++-crosssdk"

--- a/contrib/recipes-devtools/gcc/gcc-crosssdk_7.3.bb
+++ b/contrib/recipes-devtools/gcc/gcc-crosssdk_7.3.bb
@@ -1,2 +1,2 @@
 require recipes-devtools/gcc/gcc-cross_${PV}.bb
-require recipes-devtools/gcc/gcc-crosssdk.inc
+require gcc-crosssdk.inc

--- a/contrib/recipes-devtools/gcc/gcc-multilib-config.inc
+++ b/contrib/recipes-devtools/gcc/gcc-multilib-config.inc
@@ -1,0 +1,235 @@
+# following code modifies these definitions in the gcc config
+#    MULTILIB_OPTIONS
+#    MULTILIB_DIRNAMES
+#    MULTILIB_OSDIRNAMES
+#    GLIBC_DYNAMIC_LINKER32
+#    GLIBC_DYNAMIC_LINKER64
+#    GLIBC_DYNAMIC_LINKERX32
+#    GLIBC_DYNAMIC_LINKERN32
+#  For more information on use of these variables look at these files in the gcc source code
+#    gcc/config/i386/t-linux64
+#    gcc/config/mips/t-linux64
+#    gcc/config/rs6000/t-linux64
+#    gcc/config/i386/linux64.h
+#    gcc/config/mips/linux64.h
+#    gcc/config/rs6000/linux64.h
+
+MULTILIB_OPTION_WHITELIST ??= "-m32 -m64 -mx32 -mabi=n32 -mabi=32 -mabi=64" 
+
+python gcc_multilib_setup() {
+    import re
+    import shutil
+    import glob
+
+    srcdir = d.getVar('S')
+    builddir = d.getVar('B')
+    src_conf_dir = '%s/gcc/config' % srcdir
+    build_conf_dir = '%s/gcc/config' % builddir
+
+    bb.utils.remove(build_conf_dir, True)
+    ml_globs = ('%s/*/t-linux64' % src_conf_dir,
+                '%s/*/linux64.h' % src_conf_dir,
+                '%s/aarch64/t-aarch64' % src_conf_dir,
+                '%s/aarch64/aarch64.h' % src_conf_dir,
+                '%s/aarch64/aarch64-cores.def' % src_conf_dir,
+                '%s/*/linux.h' % src_conf_dir,
+                '%s/linux.h' % src_conf_dir)
+
+    # copy the target multilib config files to ${B}
+    for ml_glob in ml_globs:
+        for fn in glob.glob(ml_glob):
+            rel_path = os.path.relpath(fn, src_conf_dir)
+            parent_dir = os.path.dirname(rel_path)
+            bb.utils.mkdirhier('%s/%s' % (build_conf_dir, parent_dir))
+            bb.utils.copyfile(fn, '%s/%s' % (build_conf_dir, rel_path))
+
+    pn = d.getVar('PN')
+    multilibs = (d.getVar('MULTILIB_VARIANTS') or '').split()
+    if not multilibs and pn != "nativesdk-gcc":
+        return
+
+    mlprefix = d.getVar('MLPREFIX')
+
+    if ('%sgcc' % mlprefix) != pn and (not pn.startswith('gcc-cross-canadian')) and pn != "nativesdk-gcc":
+        return
+
+
+    def write_config(root, files, options, dirnames, osdirnames):
+        for ml_conf_file in files:
+            with open(root + '/' + ml_conf_file, 'r') as f:
+                filelines = f.readlines()
+                # recreate multilib configuration variables
+                substs = [
+                    (r'^(\s*(MULTILIB_OPTIONS\s*=).*)$', r'\2 %s' % '/'.join(options)),
+                    (r'^(\s*MULTILIB_OPTIONS\s*\+=.*)$', ''),
+                    (r'^(\s*(MULTILIB_DIRNAMES\s*=).*)$', r'\2 %s' % ' '.join(dirnames)),
+                    (r'^(\s*MULTILIB_DIRNAMES\s*\+=.*)$', ''),
+                    (r'^(\s*(MULTILIB_OSDIRNAMES\s*=).*)$', r'\2 %s' % ' '.join(osdirnames)),
+                    (r'^(\s*MULTILIB_OSDIRNAMES\s*\+=.*)$', ''),
+                ]
+
+                for (i, line) in enumerate(filelines):
+                    for subst in substs:
+                        line = re.sub(subst[0], subst[1], line)
+                    filelines[i] = line
+
+                with open(root + '/' + ml_conf_file, 'w') as f:
+                    f.write(''.join(filelines))
+
+    def write_headers(root, files, libdir32, libdir64, libdirx32, libdirn32):
+        def wrap_libdir(libdir):
+            if libdir.find('SYSTEMLIBS_DIR') != -1:
+                return '"%r"'
+            else:
+                return '"/%s/"' % libdir
+
+        for ml_conf_file in files:
+            fn = root + '/' + ml_conf_file
+            if not os.path.exists(fn):
+                continue
+            with open(fn, 'r') as f:
+                filelines = f.readlines()
+
+                # replace lines like
+                # #define GLIBC_DYNAMIC_LINKER32 SYSTEMLIBS_DIR "ld-linux.so.2"
+                # by
+                # #define GLIBC_DYNAMIC_LINKER32 "/lib/" "ld-linux.so.2"
+                # this is needed to put the correct dynamic loader path in the generated binaries
+                substs = [
+                    (r'^(#define\s*GLIBC_DYNAMIC_LINKER32\s*)(\S+)(\s*\".*\")$',
+                        r'\1' + wrap_libdir(libdir32) + r'\3'),
+                    (r'^(#define\s*GLIBC_DYNAMIC_LINKER64\s*)(\S+)(\s*\"\S+\")$',
+                        r'\1' + wrap_libdir(libdir64) + r'\3'),
+                    (r'^(#define\s*GLIBC_DYNAMIC_LINKER64\s*\"\S+\"\s*)(\S+)(\s*\"\S+\"\s*)(\S+)(\s*\".*\")$',
+                        r'\1' + wrap_libdir(libdir64) + r'\3' + wrap_libdir(libdir64) + r'\5'),
+                    (r'^(#define\s*GLIBC_DYNAMIC_LINKERX32\s*)(\S+)(\s*\".*\")$',
+                        r'\1' + wrap_libdir(libdirx32) + r'\3'),
+                    (r'^(#define\s*GLIBC_DYNAMIC_LINKERN32\s*)(\S+)(\s*\".*\")$',
+                        r'\1' + wrap_libdir(libdirn32) + r'\3'),
+                    (r'^(#define\s*UCLIBC_DYNAMIC_LINKER32\s*)(\S+)(\s*\".*\")$',
+                        r'\1' + wrap_libdir(libdir32) + r'\3'),
+                    (r'^(#define\s*UCLIBC_DYNAMIC_LINKER64\s*)(\S+)(\s*\".*\")$',
+                        r'\1' + wrap_libdir(libdir64) + r'\3'),
+                    (r'^(#define\s*UCLIBC_DYNAMIC_LINKERN32\s*)(\S+)(\s*\".*\")$',
+                        r'\1' + wrap_libdir(libdirn32) + r'\3'),
+                    (r'^(#define\s*UCLIBC_DYNAMIC_LINKER\b\s*)(\S+)(\s*\".*\")$',
+                        r'\1' + wrap_libdir(libdir32) + r'\3'),
+                ]
+
+                for (i, line) in enumerate(filelines):
+                    for subst in substs:
+                        line = re.sub(subst[0], subst[1], line)
+                    filelines[i] = line
+
+                with open(root + '/' + ml_conf_file, 'w') as f:
+                    f.write(''.join(filelines))
+
+
+    gcc_target_config_files = {
+        'x86_64'    : ['gcc/config/i386/t-linux64'],
+        'i586'      : ['gcc/config/i386/t-linux64'],
+        'i686'      : ['gcc/config/i386/t-linux64'],
+        'mips'      : ['gcc/config/mips/t-linux64'],
+        'mips64'    : ['gcc/config/mips/t-linux64'],
+        'powerpc'   : ['gcc/config/rs6000/t-linux64'],
+        'powerpc64' : ['gcc/config/rs6000/t-linux64'],
+        'aarch64'   : ['gcc/config/aarch64/t-aarch64'],
+        'arm'       : ['gcc/config/aarch64/t-aarch64'],
+    }
+
+    gcc_header_config_files = {
+        'x86_64'    : ['gcc/config/i386/linux64.h'],
+        'i586'      : ['gcc/config/i386/linux64.h'],
+        'i686'      : ['gcc/config/i386/linux64.h'],
+        'mips'      : ['gcc/config/mips/linux.h', 'gcc/config/mips/linux64.h'],
+        'mips64'    : ['gcc/config/mips/linux.h', 'gcc/config/mips/linux64.h'],
+        'powerpc'   : ['gcc/config/rs6000/linux64.h'],
+        'powerpc64' : ['gcc/config/rs6000/linux64.h'],
+        'aarch64'   : ['gcc/config/aarch64/aarch64.h'],
+        'arm'       : ['gcc/config/aarch64/aarch64.h'],
+    }
+
+    libdir32 = 'SYSTEMLIBS_DIR'
+    libdir64 = 'SYSTEMLIBS_DIR'
+    libdirx32 = 'SYSTEMLIBS_DIR'
+    libdirn32 = 'SYSTEMLIBS_DIR'
+
+
+    target_arch = (d.getVar('TARGET_ARCH_MULTILIB_ORIGINAL') if mlprefix
+                    else d.getVar('TARGET_ARCH'))
+    if pn == "nativesdk-gcc":
+        header_config_files = gcc_header_config_files[d.getVar("SDK_ARCH")]
+        write_headers(builddir, header_config_files, libdir32, libdir64, libdirx32, libdirn32)
+        return
+
+    if target_arch not in gcc_target_config_files:
+        bb.warn('gcc multilib setup is not supported for TARGET_ARCH=' + target_arch)
+        return
+
+    target_config_files = gcc_target_config_files[target_arch]
+    header_config_files = gcc_header_config_files[target_arch]
+
+    ml_list = ['DEFAULTTUNE_MULTILIB_ORIGINAL' if mlprefix else 'DEFAULTTUNE']
+    mltunes = [('DEFAULTTUNE_virtclass-multilib-%s' % ml) for ml in multilibs]
+    if mlprefix:
+        mlindex = 0
+        for ml in multilibs:
+            if mlprefix == ml + '-':
+                break
+            mlindex += 1
+
+        ml_list.extend(mltunes[:mlindex] + ['DEFAULTTUNE'] + mltunes[(mlindex + 1):])
+    else:
+        ml_list.extend(mltunes)
+
+    options = []
+    dirnames = []
+    osdirnames = []
+    optsets = []
+
+    for ml in ml_list:
+        tune = d.getVar(ml)
+        if not tune:
+            bb.warn("%s doesn't have a corresponding tune. Skipping..." % ml)
+            continue
+        tune_parameters = get_tune_parameters(tune, d)
+
+        tune_baselib = tune_parameters['baselib']
+        if not tune_baselib:
+            bb.warn("Tune %s doesn't have a baselib set. Skipping..." % tune)
+            continue
+
+        if tune_baselib == 'lib64':
+            libdir64 = tune_baselib
+        elif tune_baselib == 'libx32':
+            libdirx32 = tune_baselib
+        elif tune_baselib == 'lib32':
+            libdirn32 = tune_baselib
+        elif tune_baselib == 'lib':
+            libdir32 = tune_baselib
+        else:
+            bb.error('Unknown libdir (%s) of the tune : %s' % (tune_baselib, tune))
+
+        # take out '-' mcpu='s and march='s from parameters
+        opts = []
+        whitelist = (d.getVar("MULTILIB_OPTION_WHITELIST") or "").split()
+        for i in d.expand(tune_parameters['ccargs']).split():
+            if i in whitelist:
+                # Need to strip '-' from option
+                opts.append(i[1:])
+        options.append(" ".join(opts))
+
+        if tune_baselib == 'lib':
+            dirnames.append('32')  # /lib => 32bit lib
+        else:
+            dirnames.append(tune_baselib.replace('lib', ''))
+        osdirnames.append('../' + tune_baselib)
+
+    write_config(builddir, target_config_files, options, dirnames, osdirnames)
+    write_headers(builddir, header_config_files, libdir32, libdir64, libdirx32, libdirn32)
+}
+
+gcc_multilib_setup[cleandirs] = "${B}/gcc/config"
+gcc_multilib_setup[vardepsexclude] = "SDK_ARCH"
+
+EXTRACONFFUNCS += "gcc_multilib_setup"

--- a/contrib/recipes-devtools/gcc/gcc-runtime.inc
+++ b/contrib/recipes-devtools/gcc/gcc-runtime.inc
@@ -1,0 +1,261 @@
+require gcc-configure-common.inc
+
+SUMMARY = "Runtime libraries from GCC"
+
+# Over-ride the LICENSE set by gcc-${PV}.inc to remove "& GPLv3"
+# All gcc-runtime packages are now covered by the runtime exception.
+LICENSE = "GPL-3.0-with-GCC-exception"
+
+CXXFLAGS_remove = "-fvisibility-inlines-hidden"
+
+EXTRA_OECONF_PATHS = "\
+    --with-gxx-include-dir=${includedir}/c++/${BINV} \
+    --with-sysroot=/not/exist \
+    --with-build-sysroot=${STAGING_DIR_TARGET} \
+"
+
+EXTRA_OECONF_append_linuxstdbase = " --enable-clocale=gnu"
+
+RUNTIMELIBITM = "libitm"
+RUNTIMELIBITM_arc = ""
+RUNTIMELIBITM_mipsarch = ""
+RUNTIMELIBITM_nios2 = ""
+RUNTIMELIBITM_microblaze = ""
+RUNTIMELIBITM_riscv32 = ""
+RUNTIMELIBITM_riscv64 = ""
+RUNTIMELIBSSP ?= ""
+RUNTIMELIBSSP_mingw32 ?= "libssp"
+
+RUNTIMETARGET = "${RUNTIMELIBSSP} libstdc++-v3 libgomp libatomic ${RUNTIMELIBITM} \
+    ${@bb.utils.contains_any('FORTRAN', [',fortran',',f77'], 'libquadmath', '', d)} \
+"
+
+# libiberty
+# libmudflap
+# libgfortran needs separate recipe due to libquadmath dependency
+
+SLIB = "${TMPDIR}/work-shared/gcc-${PV}-${PR}/gcc-${PV}"
+SLIB_NEW = "/usr/src/debug/${PN}/${EXTENDPE}${PV}-${PR}"
+
+DEBUG_PREFIX_MAP_class-target = " \
+   -fdebug-prefix-map=${WORKDIR}/recipe-sysroot= \
+   -fdebug-prefix-map=${WORKDIR}/recipe-sysroot-native= \
+   -fdebug-prefix-map=${SLIB}=${SLIB_NEW} \
+   -fdebug-prefix-map=${SLIB}/include=${SLIB_NEW}/libstdc++-v3/../include \
+   -fdebug-prefix-map=${SLIB}/libiberty=${SLIB_NEW}/libstdc++-v3/../libiberty \
+   -fdebug-prefix-map=${B}=${SLIB_NEW} \
+   "
+
+do_configure () {
+	export CXX="${CXX} -nostdinc++ -nostdlib++"
+	for d in libgcc ${RUNTIMETARGET}; do
+		echo "Configuring $d"
+		rm -rf ${B}/${TARGET_SYS}/$d/
+		mkdir -p ${B}/${TARGET_SYS}/$d/
+		cd ${B}/${TARGET_SYS}/$d/
+		chmod a+x ${S}/$d/configure
+		relpath=${@os.path.relpath("${S}/$d", "${B}/${TARGET_SYS}/$d")}
+		$relpath/configure ${CONFIGUREOPTS} ${EXTRA_OECONF}
+		if [ "$d" = "libgcc" ]; then
+			(cd ${B}/${TARGET_SYS}/libgcc; oe_runmake enable-execute-stack.c unwind.h md-unwind-support.h sfp-machine.h gthr-default.h)
+		fi
+	done
+}
+EXTRACONFFUNCS += "extract_stashed_builddir"
+do_configure[depends] += "${COMPILERDEP}"
+
+do_compile () {
+	for d in libgcc ${RUNTIMETARGET}; do
+		cd ${B}/${TARGET_SYS}/$d/
+		oe_runmake MULTIBUILDTOP=${B}/${TARGET_SYS}/$d/
+	done
+}
+
+do_install () {
+	for d in ${RUNTIMETARGET}; do
+		cd ${B}/${TARGET_SYS}/$d/
+		oe_runmake 'DESTDIR=${D}' MULTIBUILDTOP=${B}/${TARGET_SYS}/$d/ install
+	done
+	rm -rf ${D}${infodir}/libgomp.info ${D}${infodir}/dir
+	rm -rf ${D}${infodir}/libitm.info ${D}${infodir}/dir
+	rm -rf ${D}${infodir}/libquadmath.info ${D}${infodir}/dir
+	if [ -d ${D}${libdir}/gcc/${TARGET_SYS}/${BINV}/finclude ]; then
+		rmdir --ignore-fail-on-non-empty -p ${D}${libdir}/gcc/${TARGET_SYS}/${BINV}/finclude
+	fi
+	if [ -d ${D}${infodir} ]; then
+		rmdir --ignore-fail-on-non-empty -p ${D}${infodir}
+	fi
+	if [ "${TARGET_VENDOR_MULTILIB_ORIGINAL}" != "" -a "${TARGET_VENDOR}" != "${TARGET_VENDOR_MULTILIB_ORIGINAL}" ]; then
+		ln -s ${TARGET_SYS} ${D}${includedir}/c++/${BINV}/${TARGET_ARCH}${TARGET_VENDOR_MULTILIB_ORIGINAL}-${TARGET_OS}
+	fi
+
+}
+
+do_install_append_class-target () {
+	if [ "${TARGET_OS}" = "linux-gnuspe" ]; then
+		ln -s ${TARGET_SYS} ${D}${includedir}/c++/${BINV}/${TARGET_ARCH}${TARGET_VENDOR}-linux
+	fi
+
+	if [ "${TARGET_OS}" = "linux-gnun32" ]; then
+		if [ "${MULTILIBS}" != "" ]; then
+			mkdir ${D}${includedir}/c++/${BINV}/${TARGET_ARCH}-pokymllib64-linux
+			ln -s ../${TARGET_SYS} ${D}${includedir}/c++/${BINV}/${TARGET_ARCH}-pokymllib64-linux/32
+		else
+			ln -s ${TARGET_SYS} ${D}${includedir}/c++/${BINV}/${TARGET_ARCH}${TARGET_VENDOR}-linux
+		fi
+	fi
+	if [ "${TARGET_OS}" = "linux-gnux32" ]; then
+		if [ "${MULTILIBS}" != "" ]; then
+			mkdir ${D}${includedir}/c++/${BINV}/${TARGET_ARCH}-poky-linux
+			ln -s ../${TARGET_SYS} ${D}${includedir}/c++/${BINV}/${TARGET_ARCH}-poky-linux/x32
+		else
+			ln -s ${TARGET_SYS} ${D}${includedir}/c++/${BINV}/${TARGET_ARCH}${TARGET_VENDOR}-linux
+		fi
+	fi
+
+	if [ "${TCLIBC}" != "glibc" ]; then
+		case "${TARGET_OS}" in
+			"linux-musl" | "linux-*spe") extra_target_os="linux";;
+			"linux-musleabi") extra_target_os="linux-gnueabi";;
+			*) extra_target_os="linux";;
+		esac
+		ln -s ${TARGET_SYS} ${D}${includedir}/c++/${BINV}/${TARGET_ARCH}${TARGET_VENDOR}-$extra_target_os
+	fi
+	chown -R root:root ${D}
+}
+
+INHIBIT_DEFAULT_DEPS = "1"
+DEPENDS = "virtual/${TARGET_PREFIX}gcc virtual/${TARGET_PREFIX}g++ libgcc virtual/${MLPREFIX}libc"
+PROVIDES = "virtual/${TARGET_PREFIX}compilerlibs"
+
+BBCLASSEXTEND = "nativesdk"
+
+PACKAGES = "\
+    ${PN}-dbg \
+    libstdc++ \
+    libstdc++-precompile-dev \
+    libstdc++-dev \
+    libstdc++-staticdev \
+    libg2c \
+    libg2c-dev \
+    libssp \
+    libssp-dev \
+    libssp-staticdev \
+    libmudflap \
+    libmudflap-dev \
+    libmudflap-staticdev \
+    libquadmath \
+    libquadmath-dev \
+    libquadmath-staticdev \
+    libgomp \
+    libgomp-dev \
+    libgomp-staticdev \
+    libatomic \
+    libatomic-dev \
+    libatomic-staticdev \
+    libitm \
+    libitm-dev \
+    libitm-staticdev \
+"
+# The base package doesn't exist, so we clear the recommends.
+RRECOMMENDS_${PN}-dbg = ""
+
+# include python debugging scripts
+FILES_${PN}-dbg += "\
+    ${libdir}/libstdc++.so.*-gdb.py \
+    ${datadir}/gcc-${BINV}/python/libstdcxx \
+"
+
+FILES_libg2c = "${target_libdir}/libg2c.so.*"
+SUMMARY_libg2c = "Companion runtime library for g77"
+FILES_libg2c-dev = "\
+    ${libdir}/libg2c.so \
+    ${libdir}/libg2c.a \
+    ${libdir}/libfrtbegin.a \
+"
+SUMMARY_libg2c-dev = "Companion runtime library for g77 - development files"
+
+FILES_libstdc++ = "${libdir}/libstdc++.so.*"
+SUMMARY_libstdc++ = "GNU standard C++ library"
+FILES_libstdc++-dev = "\
+    ${includedir}/c++/ \
+    ${libdir}/libstdc++.so \
+    ${libdir}/libstdc++*.la \
+    ${libdir}/libsupc++.la \
+"
+SUMMARY_libstdc++-dev = "GNU standard C++ library - development files"
+FILES_libstdc++-staticdev = "\
+    ${libdir}/libstdc++*.a \
+    ${libdir}/libsupc++.a \
+"
+SUMMARY_libstdc++-staticdev = "GNU standard C++ library - static development files"
+
+FILES_libstdc++-precompile-dev = "${includedir}/c++/${TARGET_SYS}/bits/*.gch"
+SUMMARY_libstdc++-precompile-dev = "GNU standard C++ library - precompiled header files"
+
+FILES_libssp = "${libdir}/libssp.so.*"
+SUMMARY_libssp = "GNU stack smashing protection library"
+FILES_libssp-dev = "\
+    ${libdir}/libssp*.so \
+    ${libdir}/libssp*_nonshared.a \
+    ${libdir}/libssp*.la \
+    ${libdir}/gcc/${TARGET_SYS}/${BINV}/include/ssp \
+"
+SUMMARY_libssp-dev = "GNU stack smashing protection library - development files"
+FILES_libssp-staticdev = "${libdir}/libssp*.a"
+SUMMARY_libssp-staticdev = "GNU stack smashing protection library - static development files"
+
+FILES_libquadmath = "${libdir}/libquadmath*.so.*"
+SUMMARY_libquadmath = "GNU quad-precision math library"
+FILES_libquadmath-dev = "\
+    ${libdir}/gcc/${TARGET_SYS}/${BINV}/include/quadmath* \
+    ${libdir}/libquadmath*.so \
+    ${libdir}/libquadmath.la \
+"
+SUMMARY_libquadmath-dev = "GNU quad-precision math library - development files"
+FILES_libquadmath-staticdev = "${libdir}/libquadmath.a"
+SUMMARY_libquadmath-staticdev = "GNU quad-precision math library - static development files"
+
+# NOTE: mudflap has been removed as of gcc 4.9 and has been superseded by the address sanitiser
+FILES_libmudflap = "${libdir}/libmudflap*.so.*"
+SUMMARY_libmudflap = "Pointer debugging library for gcc"
+FILES_libmudflap-dev = "\
+    ${libdir}/libmudflap*.so \
+    ${libdir}/libmudflap.la \
+"
+SUMMARY_libmudflap-dev = "Pointer debugging library for gcc - development files"
+FILES_libmudflap-staticdev = "${libdir}/libmudflap.a"
+SUMMARY_libmudflap-staticdev = "Pointer debugging library for gcc - static development files"
+
+FILES_libgomp = "${libdir}/libgomp*${SOLIBS}"
+SUMMARY_libgomp = "GNU OpenMP parallel programming library"
+FILES_libgomp-dev = "\
+    ${libdir}/libgomp*${SOLIBSDEV} \
+    ${libdir}/libgomp*.la \
+    ${libdir}/libgomp.spec \
+    ${libdir}/gcc/${TARGET_SYS}/${BINV}/include/omp.h \
+"
+SUMMARY_libgomp-dev = "GNU OpenMP parallel programming library - development files"
+FILES_libgomp-staticdev = "${libdir}/libgomp*.a"
+SUMMARY_libgomp-staticdev = "GNU OpenMP parallel programming library - static development files"
+
+FILES_libatomic = "${libdir}/libatomic.so.*"
+SUMMARY_libatomic = "GNU C++11 atomics support library"
+FILES_libatomic-dev = "\
+    ${libdir}/libatomic.so \
+    ${libdir}/libatomic.la \
+"
+SUMMARY_libatomic-dev = "GNU C++11 atomics support library - development files"
+FILES_libatomic-staticdev = "${libdir}/libatomic.a"
+SUMMARY_libatomic-staticdev = "GNU C++11 atomics support library - static development files"
+
+FILES_libitm = "${libdir}/libitm.so.*"
+SUMMARY_libitm = "GNU transactional memory support library"
+FILES_libitm-dev = "\
+    ${libdir}/libitm.so \
+    ${libdir}/libitm.la \
+    ${libdir}/libitm.spec \
+"
+SUMMARY_libitm-dev = "GNU transactional memory support library - development files"
+FILES_libitm-staticdev = "${libdir}/libitm.a"
+SUMMARY_libitm-staticdev = "GNU transactional memory support library - static development files"

--- a/contrib/recipes-devtools/gcc/gcc-runtime_7.3.bb
+++ b/contrib/recipes-devtools/gcc/gcc-runtime_7.3.bb
@@ -1,5 +1,5 @@
 require recipes-devtools/gcc/gcc-${PV}.inc
-require recipes-devtools/gcc/gcc-runtime.inc
+require gcc-runtime.inc
 
 FILES_libgomp-dev += "\
     ${libdir}/gcc/${TARGET_SYS}/${BINV}/include/openacc.h \

--- a/contrib/recipes-devtools/gcc/gcc-sanitizers.inc
+++ b/contrib/recipes-devtools/gcc/gcc-sanitizers.inc
@@ -1,0 +1,109 @@
+require gcc-configure-common.inc
+
+LICENSE = "NCSA | MIT"
+
+LIC_FILES_CHKSUM = "\
+    file://libsanitizer/LICENSE.TXT;md5=0249c37748936faf5b1efd5789587909 \
+"
+
+EXTRA_OECONF_PATHS = "\
+    --with-sysroot=/not/exist \
+    --with-build-sysroot=${STAGING_DIR_TARGET} \
+"
+
+do_configure () {
+    rm -rf ${B}/${TARGET_SYS}/libsanitizer/
+    mkdir -p ${B}/${TARGET_SYS}/libsanitizer/
+    cd ${B}/${TARGET_SYS}/libsanitizer/
+    chmod a+x ${S}/libsanitizer/configure
+    relpath=${@os.path.relpath("${S}/libsanitizer", "${B}/${TARGET_SYS}/libsanitizer")}
+    $relpath/configure ${CONFIGUREOPTS} ${EXTRA_OECONF}
+    # Easiest way to stop bad RPATHs getting into the library since we have a
+    # broken libtool here
+    sed -i -e 's/hardcode_into_libs=yes/hardcode_into_libs=no/' ${B}/${TARGET_SYS}/libsanitizer/libtool
+    # Link to the sysroot's libstdc++ instead of one gcc thinks it just built
+    sed -i -e '/LIBSTDCXX_RAW_CXX_\(CXXFLAGS\|LDFLAGS\)\s*=/d' ${B}/${TARGET_SYS}/libsanitizer/*/Makefile
+}
+EXTRACONFFUNCS += "extract_stashed_builddir"
+do_configure[depends] += "${COMPILERDEP}"
+
+do_compile () {
+    cd ${B}/${TARGET_SYS}/libsanitizer/
+    oe_runmake MULTIBUILDTOP=${B}/${TARGET_SYS}/libsanitizer/
+}
+
+do_install () {
+    cd ${B}/${TARGET_SYS}/libsanitizer/
+    oe_runmake 'DESTDIR=${D}' MULTIBUILDTOP=${B}/${TARGET_SYS}/libsanitizer/ install
+    if [ -d ${D}${infodir} ]; then
+        rmdir --ignore-fail-on-non-empty -p ${D}${infodir}
+    fi
+    chown -R root:root ${D}
+}
+
+INHIBIT_DEFAULT_DEPS = "1"
+ALLOW_EMPTY_${PN} = "1"
+DEPENDS = "gcc-runtime virtual/${TARGET_PREFIX}gcc"
+
+BBCLASSEXTEND = "nativesdk"
+
+PACKAGES = "${PN} ${PN}-dbg"
+PACKAGES += "libasan libubsan liblsan libtsan"
+PACKAGES += "libasan-dev libubsan-dev liblsan-dev libtsan-dev"
+PACKAGES += "libasan-staticdev libubsan-staticdev liblsan-staticdev libtsan-staticdev"
+
+RDEPENDS_libasan += "libstdc++"
+RDEPENDS_libubsan += "libstdc++"
+RDEPENDS_liblsan += "libstdc++"
+RDEPENDS_libtsan += "libstdc++"
+RDEPENDS_libasan-dev += "${PN}"
+RDEPENDS_libubsan-dev += "${PN}"
+RDEPENDS_liblsan-dev += "${PN}"
+RDEPENDS_libtsan-dev += "${PN}"
+RRECOMMENDS_${PN} += "libasan libubsan"
+RRECOMMENDS_${PN}_append_x86 = " liblsan"
+RRECOMMENDS_${PN}_append_x86-64 = " liblsan libtsan"
+RRECOMMENDS_${PN}_append_powerpc64 = " liblsan libtsan"
+RRECOMMENDS_${PN}_append_aarch64 = " liblsan libtsan"
+
+do_package_write_ipk[depends] += "virtual/${MLPREFIX}${TARGET_PREFIX}compilerlibs:do_packagedata"
+do_package_write_deb[depends] += "virtual/${MLPREFIX}${TARGET_PREFIX}compilerlibs:do_packagedata"
+do_package_write_rpm[depends] += "virtual/${MLPREFIX}${TARGET_PREFIX}compilerlibs:do_packagedata"
+
+# Only x86, powerpc, sparc, s390, arm, and aarch64 are supported
+COMPATIBLE_HOST = '(x86_64|i.86|powerpc|sparc|s390|arm|aarch64).*-linux'
+# musl is currently broken entirely
+COMPATIBLE_HOST_libc-musl = 'null'
+
+FILES_libasan += "${libdir}/libasan.so.*"
+FILES_libasan-dev += "\
+    ${libdir}/libasan_preinit.o \
+    ${libdir}/libasan.so \
+    ${libdir}/libasan.la \
+"
+FILES_libasan-staticdev += "${libdir}/libasan.a"
+
+FILES_libubsan += "${libdir}/libubsan.so.*"
+FILES_libubsan-dev += "\
+    ${libdir}/libubsan.so \
+    ${libdir}/libubsan.la \
+"
+FILES_libubsan-staticdev += "${libdir}/libubsan.a"
+
+FILES_liblsan += "${libdir}/liblsan.so.*"
+FILES_liblsan-dev += "\
+    ${libdir}/liblsan.so \
+    ${libdir}/liblsan.la \
+    ${libdir}/liblsan_preinit.o \
+"
+FILES_liblsan-staticdev += "${libdir}/liblsan.a"
+
+FILES_libtsan += "${libdir}/libtsan.so.*"
+FILES_libtsan-dev += "\
+    ${libdir}/libtsan.so \
+    ${libdir}/libtsan.la \
+    ${libdir}/libtsan_*.o \
+"
+FILES_libtsan-staticdev += "${libdir}/libtsan.a"
+
+FILES_${PN} = "${libdir}/*.spec ${libdir}/gcc/${TARGET_SYS}/${BINV}/include/sanitizer/*.h"

--- a/contrib/recipes-devtools/gcc/gcc-sanitizers_7.3.bb
+++ b/contrib/recipes-devtools/gcc/gcc-sanitizers_7.3.bb
@@ -1,2 +1,2 @@
 require recipes-devtools/gcc/gcc-${PV}.inc
-require recipes-devtools/gcc/gcc-sanitizers.inc
+require gcc-sanitizers.inc

--- a/contrib/recipes-devtools/gcc/gcc-shared-source.inc
+++ b/contrib/recipes-devtools/gcc/gcc-shared-source.inc
@@ -1,0 +1,11 @@
+do_fetch() {
+	:
+}
+do_fetch[noexec] = "1"
+deltask do_unpack
+deltask do_patch
+
+SRC_URI = ""
+
+do_configure[depends] += "gcc-source-${PV}:do_preconfigure"
+do_populate_lic[depends] += "gcc-source-${PV}:do_unpack"

--- a/contrib/recipes-devtools/gcc/gcc-source.inc
+++ b/contrib/recipes-devtools/gcc/gcc-source.inc
@@ -1,0 +1,39 @@
+deltask do_configure 
+deltask do_compile 
+deltask do_install 
+deltask do_populate_sysroot
+deltask do_populate_lic 
+RM_WORK_EXCLUDE += "${PN}"
+
+inherit nopackages
+
+PN = "gcc-source-${PV}"
+WORKDIR = "${TMPDIR}/work-shared/gcc-${PV}-${PR}"
+SSTATE_SWSPEC = "sstate:gcc::${PV}:${PR}::${SSTATE_VERSION}:"
+
+STAMP = "${STAMPS_DIR}/work-shared/gcc-${PV}-${PR}"
+STAMPCLEAN = "${STAMPS_DIR}/work-shared/gcc-${PV}-*"
+
+INHIBIT_DEFAULT_DEPS = "1"
+DEPENDS = ""
+PACKAGES = ""
+
+
+# This needs to be Python to avoid lots of shell variables becoming dependencies.
+python do_preconfigure () {
+    import subprocess
+    cmd = d.expand('cd ${S} && PATH=${PATH} gnu-configize')
+    subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
+    # See 0044-gengtypes.patch, we need to regenerate this file
+    bb.utils.remove(d.expand("${S}/gcc/gengtype-lex.c"))
+    cmd = d.expand("sed -i 's/BUILD_INFO=info/BUILD_INFO=/' ${S}/gcc/configure")
+    subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
+
+    # Easiest way to stop bad RPATHs getting into the library since we have a
+    # broken libtool here (breaks cross-canadian and target at least)
+    cmd = d.expand("sed -i -e 's/hardcode_into_libs=yes/hardcode_into_libs=no/' ${S}/libcc1/configure")
+    subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
+}
+addtask do_preconfigure after do_patch
+do_preconfigure[depends] += "gnu-config-native:do_populate_sysroot autoconf-native:do_populate_sysroot"
+

--- a/contrib/recipes-devtools/gcc/gcc-target.inc
+++ b/contrib/recipes-devtools/gcc/gcc-target.inc
@@ -1,0 +1,241 @@
+GCCMULTILIB = "--enable-multilib"
+require gcc-configure-common.inc
+
+EXTRA_OECONF_PATHS = "\
+    --with-sysroot=/ \
+    --with-build-sysroot=${STAGING_DIR_TARGET} \
+    --with-gxx-include-dir=${includedir}/c++/${BINV} \
+"
+
+EXTRA_OECONF_append_linuxstdbase = " --enable-clocale=gnu"
+
+# Configure gcc running on the target to default to an architecture which will
+# be compatible with that of gcc-runtime (which is cross compiled to be target
+# specific). For example, for ARM, ARMv6+ adds atomic instructions that may
+# affect the ABI in the gcc-runtime libs. Since we can't rely on gcc on the
+# target to always be passed -march etc, its built-in default needs to be safe.
+
+ARMFPARCHEXT ?= ""
+
+EXTRA_OECONF_append_armv6 = " --with-arch=armv6${ARMFPARCHEXT}"
+EXTRA_OECONF_append_armv7a = " --with-arch=armv7-a${ARMFPARCHEXT}"
+EXTRA_OECONF_append_armv7ve = " --with-arch=armv7ve${ARMFPARCHEXT}"
+
+# libcc1 requres gcc_cv_objdump when cross build, but gcc_cv_objdump is
+# set in subdir gcc, so subdir libcc1 can't use it, export it here to
+# fix the problem.
+export gcc_cv_objdump = "${TARGET_PREFIX}objdump"
+
+EXTRA_OECONF_GCC_FLOAT = "${@get_gcc_float_setting(bb, d)}"
+
+PACKAGES = "\
+    ${PN} ${PN}-plugins ${PN}-symlinks \
+    g++ g++-symlinks \
+    cpp cpp-symlinks \
+    g77 g77-symlinks \
+    gfortran gfortran-symlinks \
+    gcov gcov-symlinks \
+    ${PN}-doc \
+    ${PN}-dev \
+    ${PN}-dbg \
+"
+
+FILES_${PN} = "\
+    ${bindir}/${TARGET_PREFIX}gcc* \
+    ${libexecdir}/gcc/${TARGET_SYS}/${BINV}/collect2* \
+    ${libexecdir}/gcc/${TARGET_SYS}/${BINV}/cc1plus \
+    ${libexecdir}/gcc/${TARGET_SYS}/${BINV}/lto* \
+    ${libexecdir}/gcc/${TARGET_SYS}/${BINV}/lib*${SOLIBS} \
+    ${libexecdir}/gcc/${TARGET_SYS}/${BINV}/liblto*${SOLIBSDEV} \
+    ${gcclibdir}/${TARGET_SYS}/${BINV}/*.o \
+    ${gcclibdir}/${TARGET_SYS}/${BINV}/specs \
+    ${gcclibdir}/${TARGET_SYS}/${BINV}/lib*${SOLIBS} \
+    ${gcclibdir}/${TARGET_SYS}/${BINV}/include \
+    ${gcclibdir}/${TARGET_SYS}/${BINV}/include-fixed \
+"
+INSANE_SKIP_${PN} += "dev-so"
+RRECOMMENDS_${PN} += "\
+    libssp \
+    libssp-dev \
+"
+RDEPENDS_${PN} += "cpp"
+
+FILES_${PN}-dev = "\
+    ${gcclibdir}/${TARGET_SYS}/${BINV}/lib*${SOLIBSDEV} \
+    ${libexecdir}/gcc/${TARGET_SYS}/${BINV}/lib*${SOLIBSDEV} \
+    ${gcclibdir}/${TARGET_SYS}/${BINV}/plugin/include/ \
+    ${libexecdir}/gcc/${TARGET_SYS}/${BINV}/plugin/gengtype \
+    ${gcclibdir}/${TARGET_SYS}/${BINV}/plugin/gtype.state \
+"
+FILES_${PN}-symlinks = "\
+    ${bindir}/cc \
+    ${bindir}/gcc \
+    ${bindir}/gccbug \
+"
+
+FILES_${PN}-plugins = "\
+    ${gcclibdir}/${TARGET_SYS}/${BINV}/plugin \
+"
+ALLOW_EMPTY_${PN}-plugins = "1"
+
+FILES_g77 = "\
+    ${bindir}/${TARGET_PREFIX}g77 \
+    ${libexecdir}/gcc/${TARGET_SYS}/${BINV}/f771 \
+"
+FILES_g77-symlinks = "\
+    ${bindir}/g77 \
+    ${bindir}/f77 \
+"
+RRECOMMENDS_g77 = "\
+    libg2c \
+    libg2c-dev \
+"
+
+FILES_gfortran = "\
+    ${bindir}/${TARGET_PREFIX}gfortran \
+    ${libexecdir}/gcc/${TARGET_SYS}/${BINV}/f951 \
+"
+RRECOMMENDS_gfortran = "\
+    libquadmath \
+    libquadmath-dev \
+"
+FILES_gfortran-symlinks = "\
+    ${bindir}/gfortran \
+    ${bindir}/f95"
+
+FILES_cpp = "\
+    ${bindir}/${TARGET_PREFIX}cpp* \
+    ${base_libdir}/cpp \
+    ${libexecdir}/gcc/${TARGET_SYS}/${BINV}/cc1"
+FILES_cpp-symlinks = "${bindir}/cpp"
+
+FILES_gcov = "${bindir}/${TARGET_PREFIX}gcov* \
+    ${bindir}/${TARGET_PREFIX}gcov-tool* \
+"
+FILES_gcov-symlinks = "${bindir}/gcov \
+    ${bindir}/gcov-tool \
+"
+
+FILES_g++ = "\
+    ${bindir}/${TARGET_PREFIX}g++* \
+    ${libexecdir}/gcc/${TARGET_SYS}/${BINV}/cc1plus \
+"
+FILES_g++-symlinks = "\
+    ${bindir}/c++ \
+    ${bindir}/g++ \
+"
+RRECOMMENDS_g++ = "\
+    libstdc++ \
+    libstdc++-dev \
+    libatomic \
+    libatomic-dev \
+"
+
+FILES_${PN}-doc = "\
+    ${infodir} \
+    ${mandir} \
+    ${gcclibdir}/${TARGET_SYS}/${BINV}/include/README \
+"
+
+do_compile () {
+	oe_runmake all-host
+}
+
+do_install () {
+	oe_runmake 'DESTDIR=${D}' install-host
+
+	# Add unwind.h, it comes from libgcc which we don't want to build again
+	install ${STAGING_LIBDIR_NATIVE}/${TARGET_SYS}/gcc/${TARGET_SYS}/${BINV}/include/unwind.h ${D}${libdir}/gcc/${TARGET_SYS}/${BINV}/include/
+
+	# Info dir listing isn't interesting at this point so remove it if it exists.
+	if [ -e "${D}${infodir}/dir" ]; then
+		rm -f ${D}${infodir}/dir
+	fi
+
+	# Cleanup some of the ${libdir}{,exec}/gcc stuff ...
+	rm -r ${D}${libdir}/gcc/${TARGET_SYS}/${BINV}/install-tools
+	rm -r ${D}${libexecdir}/gcc/${TARGET_SYS}/${BINV}/install-tools
+	rm -rf ${D}${libexecdir}/gcc/${TARGET_SYS}/${BINV}/*.la
+	rmdir ${D}${includedir}
+	rm -rf ${D}${libdir}/gcc/${TARGET_SYS}/${BINV}/finclude
+
+	# Hack around specs file assumptions
+	test -f ${D}${libdir}/gcc/${TARGET_SYS}/${BINV}/specs && sed -i -e '/^*cross_compile:$/ { n; s/1/0/; }' ${D}${libdir}/gcc/${TARGET_SYS}/${BINV}/specs
+
+	# Cleanup manpages..
+	rm -rf ${D}${mandir}/man7
+
+	cd ${D}${bindir}
+
+	# We care about g++ not c++
+	rm -f *c++*
+
+	# We don't care about the gcc-<version> ones for this
+	rm -f *gcc-?.?*
+
+	# We use libiberty from binutils
+	find ${D}${libdir} -name libiberty.a | xargs rm -f
+	find ${D}${libdir} -name libiberty.h | xargs rm -f
+
+	# Not sure why we end up with these but we don't want them...
+	rm -f ${TARGET_PREFIX}${TARGET_PREFIX}*
+
+	# Symlinks so we can use these trivially on the target
+	if [ -e ${TARGET_PREFIX}g77 ]; then
+		ln -sf ${TARGET_PREFIX}g77 g77 || true
+		ln -sf g77 f77 || true
+	fi
+	if [ -e ${TARGET_PREFIX}gfortran ]; then
+		ln -sf ${TARGET_PREFIX}gfortran gfortran || true
+		ln -sf gfortran f95 || true
+	fi
+	ln -sf ${TARGET_PREFIX}g++ g++
+	ln -sf ${TARGET_PREFIX}gcc gcc
+	ln -sf ${TARGET_PREFIX}cpp cpp
+	ln -sf ${TARGET_PREFIX}gcov gcov
+	ln -sf ${TARGET_PREFIX}gcov-tool gcov-tool
+	install -d ${D}${base_libdir}
+	ln -sf ${bindir}/${TARGET_PREFIX}cpp ${D}${base_libdir}/cpp
+	ln -sf g++ c++
+	ln -sf gcc cc
+
+	chown -R root:root ${D}
+}
+
+do_install_append () {
+        #
+        # Thefixinc.sh script, run on the gcc's compile phase, looks into sysroot header
+        # files and places the modified files into
+        # {D}${libdir}/gcc/${TARGET_SYS}/${BINV}/include-fixed folder. This makes the
+        # build not deterministic. The following code prunes all those headers
+        # except those under include-fixed/linux, *limits.h and README, yielding
+        # the same include-fixed folders no matter what sysroot
+
+        include_fixed="${D}${libdir}/gcc/${TARGET_SYS}/${BINV}/include-fixed"
+        for f in $(find ${include_fixed} -type f); do
+                case $f in
+                */include-fixed/linux/*)
+                    continue
+                    ;;
+                */include-fixed/*limits.h)
+                    continue
+                    ;;
+                */include-fixed/README)
+                    continue
+                    ;;
+                *)
+                    # remove file and directory if empty
+                    bbdebug 2 "Pruning $f"
+                    rm $f
+                    find $(dirname $f) -maxdepth 0 -empty -exec rmdir {} \;
+                    ;;
+                esac
+        done
+}
+
+# Installing /usr/lib/gcc/* means we'd have two copies, one from gcc-cross
+# and one from here. These can confuse gcc cross where includes use #include_next
+# and builds track file dependencies (e.g. perl and its makedepends code).
+# For determinism we don't install this ever and rely on the copy from gcc-cross.
+# [YOCTO #7287]
+SYSROOT_DIRS_BLACKLIST += "${libdir}/gcc"

--- a/contrib/recipes-devtools/gcc/gcc_7.3.bb
+++ b/contrib/recipes-devtools/gcc/gcc_7.3.bb
@@ -1,5 +1,5 @@
 require recipes-devtools/gcc/gcc-${PV}.inc
-require recipes-devtools/gcc/gcc-target.inc
+require gcc-target.inc
 
 # Building with thumb enabled on armv4t armv5t fails with
 # | gcc-4.8.1-r0/gcc-4.8.1/gcc/cp/decl.c:7438:(.text.unlikely+0x2fa): relocation truncated to fit: R_ARM_THM_CALL against symbol `fancy_abort(char const*, int, char const*)' defined in .glue_7 section in linker stubs

--- a/contrib/recipes-devtools/gcc/libgcc-common.inc
+++ b/contrib/recipes-devtools/gcc/libgcc-common.inc
@@ -1,0 +1,160 @@
+BPN = "libgcc"
+
+require gcc-configure-common.inc
+
+INHIBIT_DEFAULT_DEPS = "1"
+
+do_configure () {
+	install -d ${D}${base_libdir} ${D}${libdir}
+	mkdir -p ${B}/${BPN}
+	mkdir -p ${B}/${TARGET_SYS}/${BPN}/
+	cd ${B}/${BPN}
+	chmod a+x ${S}/${BPN}/configure
+	relpath=${@os.path.relpath("${S}/${BPN}", "${B}/${BPN}")}
+	$relpath/configure ${CONFIGUREOPTS} ${EXTRA_OECONF}
+}
+EXTRACONFFUNCS += "extract_stashed_builddir"
+do_configure[depends] += "${COMPILERDEP}"
+
+do_compile () {
+	cd ${B}/${BPN}
+	oe_runmake MULTIBUILDTOP=${B}/${TARGET_SYS}/${BPN}/
+}
+
+do_install () {
+	cd ${B}/${BPN}
+	oe_runmake 'DESTDIR=${D}' MULTIBUILDTOP=${B}/${TARGET_SYS}/${BPN}/ install
+
+	# Move libgcc_s into /lib
+	mkdir -p ${D}${base_libdir}
+	if [ -f ${D}${libdir}/nof/libgcc_s.so ]; then
+		mv ${D}${libdir}/nof/libgcc* ${D}${base_libdir}
+	else
+		mv ${D}${libdir}/libgcc* ${D}${base_libdir} || true
+	fi
+
+	# install the runtime in /usr/lib/ not in /usr/lib/gcc on target
+	# so that cross-gcc can find it in the sysroot
+
+	mv ${D}${libdir}/gcc/* ${D}${libdir}
+	rm -rf ${D}${libdir}/gcc/
+	# unwind.h is installed here which is shipped in gcc-cross
+	# as well as target gcc and they are identical so we dont
+	# ship one with libgcc here
+	rm -rf ${D}${libdir}/${TARGET_SYS}/${BINV}/include
+}
+
+do_install_append_libc-baremetal () {
+	rmdir ${D}${base_libdir}
+}
+do_install_append_libc-newlib () {
+	rmdir ${D}${base_libdir}
+}
+
+# No rpm package is actually created but -dev depends on it, avoid dnf error
+RDEPENDS_${PN}-dev_libc-baremetal = ""
+RDEPENDS_${PN}-dev_libc-newlib = ""
+
+BBCLASSEXTEND = "nativesdk"
+
+addtask multilib_install after do_install before do_package do_populate_sysroot
+# this makes multilib gcc files findable for target gcc
+# e.g.
+#    /usr/lib/i586-pokymllib32-linux/4.7/
+# by creating this symlink to it
+#    /usr/lib64/x86_64-poky-linux/4.7/32
+
+fakeroot python do_multilib_install() {
+    import re
+
+    multilibs = d.getVar('MULTILIB_VARIANTS')
+    if not multilibs or bb.data.inherits_class('nativesdk', d):
+        return
+
+    binv = d.getVar('BINV')
+
+    mlprefix = d.getVar('MLPREFIX')
+    if ('%slibgcc' % mlprefix) != d.getVar('PN'):
+        return
+
+    if mlprefix:
+        orig_tune = d.getVar('DEFAULTTUNE_MULTILIB_ORIGINAL')
+        orig_tune_params = get_tune_parameters(orig_tune, d)
+        orig_tune_baselib = orig_tune_params['baselib']
+        orig_tune_bitness = orig_tune_baselib.replace('lib', '')
+        if not orig_tune_bitness:
+            orig_tune_bitness = '32'
+
+        src = '../../../' + orig_tune_baselib + '/' + \
+            d.getVar('TARGET_SYS_MULTILIB_ORIGINAL') + '/' + binv + '/'
+
+        dest = d.getVar('D') + d.getVar('libdir') + '/' + \
+            d.getVar('TARGET_SYS') + '/' + binv + '/' + orig_tune_bitness
+
+        if os.path.lexists(dest):
+            os.unlink(dest)
+        os.symlink(src, dest)
+        return
+
+
+    for ml in multilibs.split():
+        tune = d.getVar('DEFAULTTUNE_virtclass-multilib-' + ml)
+        if not tune:
+            bb.warn('DEFAULTTUNE_virtclass-multilib-%s is not defined. Skipping...' % ml)
+            continue
+
+        tune_parameters = get_tune_parameters(tune, d)
+        tune_baselib = tune_parameters['baselib']
+        if not tune_baselib:
+            bb.warn("Tune %s doesn't have a baselib set. Skipping..." % tune)
+            continue
+
+        tune_arch = tune_parameters['arch']
+        tune_bitness = tune_baselib.replace('lib', '')
+        if not tune_bitness:
+            tune_bitness = '32' # /lib => 32bit lib
+
+        tune_abiextension = tune_parameters['abiextension']
+        if tune_abiextension:
+            libcextension = '-gnu' + tune_abiextension
+        else:
+            libcextension = ''
+
+        src = '../../../' + tune_baselib + '/' + \
+            tune_arch + d.getVar('TARGET_VENDOR') + 'ml' + ml + \
+            '-' + d.getVar('TARGET_OS') + libcextension +  '/' + binv + '/'
+
+        dest = d.getVar('D') + d.getVar('libdir') + '/' + \
+            d.getVar('TARGET_SYS') + '/' + binv + '/' + tune_bitness
+
+        if os.path.lexists(dest):
+            os.unlink(dest)
+        os.symlink(src, dest)
+}
+
+def get_original_os(d):
+    vendoros = d.expand('${TARGET_ARCH}${ORIG_TARGET_VENDOR}-${TARGET_OS}')
+    for suffix in [d.getVar('ABIEXTENSION'), d.getVar('LIBCEXTENSION')]:
+        if suffix and vendoros.endswith(suffix):
+            vendoros = vendoros[:-len(suffix)]
+    # Arm must use linux-gnueabi not linux as only the former is accepted by gcc
+    if vendoros.startswith("arm-") and not vendoros.endswith("-gnueabi"):
+        vendoros = vendoros + "-gnueabi"
+    return vendoros
+
+ORIG_TARGET_VENDOR := "${TARGET_VENDOR}"
+BASETARGET_SYS = "${@get_original_os(d)}"
+
+addtask extra_symlinks after do_multilib_install before do_package do_populate_sysroot
+fakeroot python do_extra_symlinks() {
+    if bb.data.inherits_class('nativesdk', d):
+        return
+
+    targetsys = d.getVar('BASETARGET_SYS')
+
+    if targetsys != d.getVar('TARGET_SYS'):
+        dest = d.getVar('D') + d.getVar('libdir') + '/' + targetsys
+        src = d.getVar('TARGET_SYS')
+        if not os.path.lexists(dest) and os.path.lexists(d.getVar('D') + d.getVar('libdir')):
+            os.symlink(src, dest)
+}

--- a/contrib/recipes-devtools/gcc/libgcc-initial.inc
+++ b/contrib/recipes-devtools/gcc/libgcc-initial.inc
@@ -1,0 +1,58 @@
+#
+# Notes on the way the OE cross toolchain now works
+#
+# We need a libgcc to build glibc. Tranditionally we therefore built
+# a non-threaded and non-shared compiler (gcc-cross-initial), then use
+# that to build libgcc-initial which is used to build glibc which we can
+# then build gcc-cross and libgcc against.
+#
+# We were able to drop the glibc dependency from gcc-cross, with two tweaks:
+
+# a) specify the minimum glibc version to support in a configure option
+# b) create a dummy limits.h file so that later when glibc creates one,
+#    the headers structure has support for it. We can do this with a simple
+#    empty file
+#
+# Once gcc-cross is libc independent, we can use it to build both
+# libgcc-initial and then later libgcc.
+#
+# libgcc-initial is tricky as we need to imitate the non-threaded and
+# non-shared case. We can do that by hacking the threading mode back to
+# "single" even if gcc reports "posix" and disable libc presence for the
+# libgcc-intial build. We have to create the dummy limits.h to avoid
+# compiler errors from a missing header.
+#
+# glibc will fail to link with libgcc-initial due to a missing "exception
+# handler" capable libgcc (libgcc_eh.a). Since we know glibc doesn't need
+# any exception handler, we can safely symlink to libgcc.a.
+#
+
+require libgcc-common.inc
+
+DEPENDS = "virtual/${TARGET_PREFIX}gcc"
+
+LICENSE = "GPL-3.0-with-GCC-exception"
+
+PACKAGES = ""
+
+EXTRA_OECONF += "--disable-shared"
+
+inherit nopackages
+
+# We really only want this built by things that need it, not any recrdeptask
+deltask do_build
+
+do_configure_prepend () {
+	install -d ${STAGING_INCDIR}
+	touch ${STAGING_INCDIR}/limits.h
+	sed -i -e 's#INHIBIT_LIBC_CFLAGS =.*#INHIBIT_LIBC_CFLAGS = -Dinhibit_libc#' ${B}/gcc/libgcc.mvars
+	sed -i -e 's#inhibit_libc = false#inhibit_libc = true#' ${B}/gcc/Makefile
+}
+
+do_configure_append () {
+	sed -i -e 's#thread_header = .*#thread_header = gthr-single.h#' ${B}/${BPN}/Makefile
+}
+
+do_install_append () {
+	ln -s libgcc.a ${D}${libdir}/${TARGET_SYS}/${BINV}/libgcc_eh.a
+}

--- a/contrib/recipes-devtools/gcc/libgcc-initial_7.3.bb
+++ b/contrib/recipes-devtools/gcc/libgcc-initial_7.3.bb
@@ -1,2 +1,12 @@
 require recipes-devtools/gcc/gcc-${PV}.inc
-require recipes-devtools/gcc/libgcc-initial.inc
+require libgcc-initial.inc
+
+#autotools_preconfigure_append() {
+#do_configure_prepend () {
+#	#echo "TEST TEST TEST TEST TEST TEST TEST TEST TEST"
+#	#echo `pwd`
+#        #for file in $(grep -rl '\-V -qversion' ${S}/../../.. ) ; do
+#	for file in $(grep -rl '\-V -qversion' ${S} ) ; do
+#                sed -i 's/ -V -qversion/ /g' $file
+#        done
+#}

--- a/contrib/recipes-devtools/gcc/libgcc.inc
+++ b/contrib/recipes-devtools/gcc/libgcc.inc
@@ -1,0 +1,42 @@
+require libgcc-common.inc
+
+DEPENDS = "virtual/${TARGET_PREFIX}gcc virtual/${TARGET_PREFIX}g++ virtual/${MLPREFIX}libc"
+
+do_install_append_class-target () {
+	if [ "${TCLIBC}" != "glibc" ]; then
+		case "${TARGET_OS}" in
+			"linux-musl" | "linux-*spe") extra_target_os="linux";;
+			"linux-musleabi") extra_target_os="linux-gnueabi";;
+			*) extra_target_os="linux";;
+		esac
+		ln -s ${TARGET_SYS} ${D}${libdir}/${TARGET_ARCH}${TARGET_VENDOR}-$extra_target_os
+	fi
+}
+
+PACKAGES = "\
+    ${PN} \
+    ${PN}-dev \
+    ${PN}-dbg \
+"
+
+# All libgcc source is marked with the exception.
+#
+LICENSE_${PN} = "GPL-3.0-with-GCC-exception"
+LICENSE_${PN}-dev = "GPL-3.0-with-GCC-exception"
+LICENSE_${PN}-dbg = "GPL-3.0-with-GCC-exception"
+
+
+FILES_${PN}-dev = "\
+    ${base_libdir}/libgcc*.so \
+    ${@oe.utils.conditional('BASETARGET_SYS', '${TARGET_SYS}', '', '${libdir}/${BASETARGET_SYS}', d)} \
+    ${libdir}/${TARGET_SYS}/${BINV}* \
+    ${libdir}/${TARGET_ARCH}${TARGET_VENDOR}* \
+"
+
+do_package[depends] += "virtual/${MLPREFIX}libc:do_packagedata"
+do_package_write_ipk[depends] += "virtual/${MLPREFIX}libc:do_packagedata"
+do_package_write_deb[depends] += "virtual/${MLPREFIX}libc:do_packagedata"
+do_package_write_rpm[depends] += "virtual/${MLPREFIX}libc:do_packagedata"
+
+INSANE_SKIP_${PN}-dev = "staticdev"
+

--- a/contrib/recipes-devtools/gcc/libgcc_7.3.bb
+++ b/contrib/recipes-devtools/gcc/libgcc_7.3.bb
@@ -1,2 +1,2 @@
 require recipes-devtools/gcc/gcc-${PV}.inc
-require recipes-devtools/gcc/libgcc.inc
+require libgcc.inc

--- a/contrib/recipes-devtools/gcc/libgfortran.inc
+++ b/contrib/recipes-devtools/gcc/libgfortran.inc
@@ -1,0 +1,77 @@
+require gcc-configure-common.inc
+
+EXTRA_OECONF_PATHS = "\
+    --with-sysroot=/not/exist \
+    --with-build-sysroot=${STAGING_DIR_TARGET} \
+"
+
+do_configure () {
+	for target in libbacktrace libgfortran
+	do
+		rm -rf ${B}/${TARGET_SYS}/$target/
+		mkdir -p ${B}/${TARGET_SYS}/$target/
+		cd ${B}/${TARGET_SYS}/$target/
+		chmod a+x ${S}/$target/configure
+		relpath=${@os.path.relpath("${S}", "${B}/${TARGET_SYS}")}
+		../$relpath/$target/configure ${CONFIGUREOPTS} ${EXTRA_OECONF}
+		# Easiest way to stop bad RPATHs getting into the library since we have a
+		# broken libtool here
+		sed -i -e 's/hardcode_into_libs=yes/hardcode_into_libs=no/' ${B}/${TARGET_SYS}/$target/libtool
+	done
+}
+EXTRACONFFUNCS += "extract_stashed_builddir"
+do_configure[depends] += "${COMPILERDEP}"
+
+do_compile () {
+	for target in libbacktrace libgfortran
+	do
+		cd ${B}/${TARGET_SYS}/$target/
+		oe_runmake MULTIBUILDTOP=${B}/${TARGET_SYS}/$target/
+	done
+}
+
+do_install () {
+	cd ${B}/${TARGET_SYS}/libgfortran/
+	oe_runmake 'DESTDIR=${D}' MULTIBUILDTOP=${B}/${TARGET_SYS}/libgfortran/ install
+	if [ -d ${D}${libdir}/gcc/${TARGET_SYS}/${BINV}/finclude ]; then
+		rmdir --ignore-fail-on-non-empty -p ${D}${libdir}/gcc/${TARGET_SYS}/${BINV}/finclude
+	fi
+	if [ -d ${D}${infodir} ]; then
+		rmdir --ignore-fail-on-non-empty -p ${D}${infodir}
+	fi
+	chown -R root:root ${D}
+}
+
+INHIBIT_DEFAULT_DEPS = "1"
+DEPENDS = "gcc-runtime gcc-cross-${TARGET_ARCH}"
+
+BBCLASSEXTEND = "nativesdk"
+
+PACKAGES = "\
+    ${PN}-dbg \
+    libgfortran \
+    libgfortran-dev \
+    libgfortran-staticdev \
+"
+FILES_${PN} = "${libdir}/libgfortran.so.*"
+FILES_${PN}-dev = "\
+    ${libdir}/libgfortran*.so \
+    ${libdir}/libgfortran.spec \
+    ${libdir}/libgfortran.la \
+    ${libdir}/gcc/${TARGET_SYS}/${BINV}/libgfortranbegin.* \
+    ${libdir}/gcc/${TARGET_SYS}/${BINV}/libcaf_single* \
+    ${libdir}/gcc/${TARGET_SYS}/${BINV}/finclude/ \
+"
+FILES_${PN}-staticdev = "${libdir}/libgfortran.a"
+
+INSANE_SKIP_${MLPREFIX}libgfortran-dev = "staticdev"
+
+do_package_write_ipk[depends] += "virtual/${MLPREFIX}libc:do_packagedata"
+do_package_write_deb[depends] += "virtual/${MLPREFIX}libc:do_packagedata"
+do_package_write_rpm[depends] += "virtual/${MLPREFIX}libc:do_packagedata"
+
+python __anonymous () {
+    f = d.getVar("FORTRAN")
+    if "fortran" not in f:
+        raise bb.parse.SkipRecipe("libgfortran needs fortran support to be enabled in the compiler")
+}

--- a/contrib/recipes-devtools/gcc/libgfortran_7.3.bb
+++ b/contrib/recipes-devtools/gcc/libgfortran_7.3.bb
@@ -1,3 +1,3 @@
 require recipes-devtools/gcc/gcc-${PV}.inc
-require recipes-devtools/gcc/libgfortran.inc
+require libgfortran.inc
 


### PR DESCRIPTION
Using .inc files for GCC 9 by GCC 7 leads to issues with missing
omp.h while building UnifiedMemoryStreams from cuda-samples.
By porting apppropriate include files from release Thud of the
Yocto Project to the contrib sub-layer these issues are avoided.

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>