### PR TITLE
tegra1xx-flash-helper.sh: add ability to set arbitrary flash command

### DIFF
--- a/recipes-bsp/tegra-binaries/files/tegra186-flash-helper.sh
+++ b/recipes-bsp/tegra-binaries/files/tegra186-flash-helper.sh
@@ -3,6 +3,8 @@ bup_build=
 keyfile=
 sbk_keyfile=
 no_flash=0
+flash_cmd=
+
 ARGS=$(getopt -n $(basename "$0") -l "bup,no-flash" -o "u:v:" -- "$@")
 if [ $? -ne 0 ]; then
     echo "Error parsing options" >&2
@@ -26,6 +28,10 @@ while true; do
 	    ;;
 	-v)
 	    sbk_keyfile="$2"
+	    shift 2
+	    ;;
+	-c)
+	    flash_cmd="$2"
 	    shift 2
 	    ;;
 	--)
@@ -187,7 +193,7 @@ elif [ -n "$keyfile" ]; then
     fi
     exit 0
 else
-    tfcmd="flash;reboot"
+    tfcmd=${flash_cmd:-"flash;reboot"}
 fi
 
 flashcmd="python $flashappname --chip 0x18 --bl nvtboot_recovery_cpu.bin \

--- a/recipes-bsp/tegra-binaries/files/tegra194-flash-helper.sh
+++ b/recipes-bsp/tegra-binaries/files/tegra194-flash-helper.sh
@@ -3,6 +3,7 @@ bup_build=
 keyfile=
 sbk_keyfile=
 no_flash=0
+flash_cmd=
 
 ARGS=$(getopt -n $(basename "$0") -l "bup,no-flash" -o "u:v:" -- "$@")
 if [ $? -ne 0 ]; then
@@ -27,6 +28,10 @@ while true; do
 	    ;;
 	-v)
 	    sbk_keyfile="$2"
+	    shift 2
+	    ;;
+	-c)
+	    flash_cmd="$2"
 	    shift 2
 	    ;;
 	--)
@@ -230,7 +235,7 @@ elif [ -n "$keyfile" ]; then
     fi
     exit 0
 else
-    tfcmd="flash;reboot"
+    tfcmd=${flash_cmd:-"flash;reboot"}
 fi
 
 flashcmd="python $flashappname --chip 0x19 --bl nvtboot_recovery_cpu_t194.bin \


### PR DESCRIPTION
The flash helper scripts can be used to flash the whole system, but
individual partitions can also be programmed by changing the command
sent to the recovery mode program.

This change adds a '-c' argument to the t186 and t194 flash helper
scripts.

It can be used, e.g. to program just the kernel partition:

    tegra194-flash-helper.sh -c "signwrite kernel ${DEPLOY_DIR}/tegra-minimal-initramfs-jetson-xavier.cpio.gz.cboot;reboot" flash.xml.in tegra194-p2888-0001-p2822-0000.dtb jetson-xavier.cfg,jetson-xavier-override.cfg 0x9190000

Or e.g. the device tree partition:

    tegra194-flash-helper.sh -c "signwrite kernel ${DEPLOY_DIR}/tegra194-p2888-0001-p2822-0000.dtb;reboot" flash.xml.in tegra194-p2888-0001-p2822-0000.dtb jetson-xavier.cfg,jetson-xavier-override.cfg 0x9190000