### PR TITLE
image_types_tegra.bbclass: Deploy cboot.bin

### DIFF
--- a/classes/image_types_tegra.bbclass
+++ b/classes/image_types_tegra.bbclass
@@ -511,7 +511,8 @@ do_image_tegraflash[depends] += "zip-native:do_populate_sysroot dtc-native:do_po
                                  tegra-bootfiles:do_populate_sysroot tegra-bootfiles:do_populate_lic \
                                  virtual/kernel:do_deploy ${TEGRAFLASHDEPS} \
                                  ${@'${INITRD_IMAGE}:do_image_complete' if d.getVar('INITRD_IMAGE') != '' else  ''} \
-                                 ${@'${IMAGE_UBOOT}:do_deploy ${IMAGE_UBOOT}:do_populate_lic' if d.getVar('IMAGE_UBOOT') != '' else  ''}"
+                                 ${@'${IMAGE_UBOOT}:do_deploy ${IMAGE_UBOOT}:do_populate_lic' if d.getVar('IMAGE_UBOOT') != '' else  ''} \
+                                 ${@'cboot:do_deploy' if d.getVar('IMAGE_UBOOT') != '' and d.getVar('SOC_FAMILY') == 'tegra186' else  ''}"
 IMAGE_TYPEDEP_tegraflash += "${IMAGE_TEGRAFLASH_FS_TYPE}"
 
 oe_make_bup_payload() {


### PR DESCRIPTION
For Jetson TX2, the default configuration uses cboot to load
U-Boot. Script doflash.sh requires cboot.bin. If it is not
present the scripts fails with:

Error: Return value 4

This fix ensures that task do_deploy of cboot will be executed
and cboot.bin will be present even if U-Boot has been selected
as a bootloader.

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>