### PR TITLE
fixed potential typo in tegra186-flash-helper.sh

### DIFF
--- a/recipes-bsp/tegra-binaries/files/tegra186-flash-helper.sh
+++ b/recipes-bsp/tegra-binaries/files/tegra186-flash-helper.sh
@@ -118,7 +118,7 @@ elif [ "$boardid" = "3489" ]; then
     TOREV="a00"
     PMICREV="a00"
     BPFDTBREV="a00";
-    if [ "${boardver}" < "300" ]; then
+    if [ "$board_version" < "300" ]; then
         BPFDTBREV="evt"
     fi
 else


### PR DESCRIPTION
It seems to me `boardrev` should be `board_version`