### PR TITLE
fixed if statement evaluation

### DIFF
--- a/recipes-bsp/tegra-binaries/files/tegra186-flash-helper.sh
+++ b/recipes-bsp/tegra-binaries/files/tegra186-flash-helper.sh
@@ -118,7 +118,7 @@ elif [ "$boardid" = "3489" ]; then
     TOREV="a00"
     PMICREV="a00"
     BPFDTBREV="a00";
-    if [ "$board_version" < "300" ]; then
+    if [[ "$board_version" < "300" ]]; then
         BPFDTBREV="evt"
     fi
 else


### PR DESCRIPTION
the "[ "$board_version" < "300" ]" statement is not properly evaluated
due to the quirky syntax of Bash.
We can either change it to double bracket or "-lt".