### PR TITLE
Correct nvpmodel support for xavier 8gb

### DIFF
--- a/conf/machine/jetson-xavier-8gb.conf
+++ b/conf/machine/jetson-xavier-8gb.conf
@@ -10,3 +10,5 @@ TEGRA_BOARDSKU ?= "0006"
 TEGRA_BOARDREV ?= "B.0"
 
 include conf/machine/jetson-xavier.conf
+
+MACHINEOVERRIDES .= ":xavier-8gb"

--- a/recipes-bsp/tegra-binaries/tegra-nvpmodel_32.2.3.bb
+++ b/recipes-bsp/tegra-binaries/tegra-nvpmodel_32.2.3.bb
@@ -17,6 +17,7 @@ do_compile[noexec] = "1"
 NVPMODEL = ""
 NVPMODEL_tegra186 ?= "nvpmodel_t186"
 NVPMODEL_tegra194 ?= "nvpmodel_t194"
+NVPMODEL_xavier-8gb ?= "nvpmodel_t194_8gb"
 NVPMODEL_tegra210 ?= "nvpmodel_t210"
 NVPMODEL_jetson-nano ?= "nvpmodel_t210_jetson-nano"
 


### PR DESCRIPTION
The xavier 8gb module uses a different nvpmodel.conf than its big brother. This change installs the right version, based on a specific `MACHINEOVERRIDES` for this module.