### PR TITLE
recipes-containers: add libnvidia-container-tools package to yocto

### DIFF
--- a/recipes-containers/libnvidia-container-tools/libnvidia-container-tools/0001-Makefile-Fix-RCP-flags-and-change-prefix.patch
+++ b/recipes-containers/libnvidia-container-tools/libnvidia-container-tools/0001-Makefile-Fix-RCP-flags-and-change-prefix.patch
@@ -1,0 +1,90 @@
+From dbe33851b5084f461fbddad1999788e11fcd99a5 Mon Sep 17 00:00:00 2001
+From: Pablo Rodriguez Quesada <pablo.rodriguez-quesada@windriver.com>
+Date: Fri, 31 Jan 2020 23:23:26 +0000
+Subject: [PATCH] Makefile: Fix RCP flags and change prefix
+
+Signed-off-by: Pablo Rodriguez Quesada <prodrigu@yow-lpggp3.wrs.com>
+
+RCP -ltirpc flag was missing.
+Also prefix env variable in Makefile is fixed and this is not
+compatible with yocto builds.
+---
+ Makefile | 31 ++++++++++++++++++-------------
+ 1 file changed, 18 insertions(+), 13 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index d6fd53e..7406871 100644
+--- a/Makefile
++++ b/Makefile
+@@ -13,14 +13,14 @@ WITH_SECCOMP ?= yes
+ 
+ ##### Global definitions #####
+ 
+-export prefix      = /usr/local
+-export exec_prefix = $(prefix)
+-export bindir      = $(exec_prefix)/bin
+-export libdir      = $(exec_prefix)/lib
+-export docdir      = $(prefix)/share/doc
+-export libdbgdir   = $(prefix)/lib/debug$(libdir)
+-export includedir  = $(prefix)/include
+-export pkgconfdir  = $(libdir)/pkgconfig
++export prefix      ?= /usr/local
++export exec_prefix ?= $(prefix)
++export bindir      ?= $(exec_prefix)/bin
++export libdir      ?= $(exec_prefix)/lib
++export docdir      ?= $(prefix)/share/doc
++export libdbgdir   ?= $(libdir)/.debug$(libdir)
++export includedir  ?= $(prefix)/include
++export pkgconfdir  ?= $(libdir)/pkgconfig
+ 
+ export PKG_DIR     ?= $(CURDIR)/pkg
+ export SRCS_DIR    ?= $(CURDIR)/src
+@@ -111,7 +111,8 @@ CFLAGS   := -std=gnu11 -O2 -g -fdata-sections -ffunction-sections -fstack-protec
+             -Wall -Wextra -Wcast-align -Wpointer-arith -Wmissing-prototypes -Wnonnull \
+             -Wwrite-strings -Wlogical-op -Wformat=2 -Wmissing-format-attribute -Winit-self -Wshadow \
+             -Wstrict-prototypes -Wunreachable-code -Wconversion -Wsign-conversion \
+-            -Wno-unknown-warning-option -Wno-format-extra-args -Wno-gnu-alignof-expression $(CFLAGS)
++            -Wno-unknown-warning-option -Wno-format-extra-args -Wno-gnu-alignof-expression \
++	    -I/usr/include/tirpc $(CFLAGS)
+ LDFLAGS  := -Wl,-zrelro -Wl,-znow -Wl,-zdefs -Wl,--gc-sections $(LDFLAGS)
+ LDLIBS   := $(LDLIBS)
+ 
+@@ -120,7 +121,7 @@ LIB_CPPFLAGS       = -DNV_LINUX -isystem $(DEPS_DIR)$(includedir) -include $(BUI
+ LIB_CFLAGS         = -fPIC
+ LIB_LDFLAGS        = -L$(DEPS_DIR)$(libdir) -shared -Wl,-soname=$(LIB_SONAME)
+ LIB_LDLIBS_STATIC  = -l:libnvidia-modprobe-utils.a
+-LIB_LDLIBS_SHARED  = -ldl -lcap
++LIB_LDLIBS_SHARED  = -ldl -lcap -ltirpc
+ ifeq ($(WITH_LIBELF), yes)
+ LIB_CPPFLAGS       += -DWITH_LIBELF
+ LIB_LDLIBS_SHARED  += -lelf
+@@ -149,6 +150,10 @@ BIN_CFLAGS         = -I$(SRCS_DIR) -fPIE -flto $(CFLAGS)
+ BIN_LDFLAGS        = -L. -pie $(LDFLAGS) -Wl,-rpath='$$ORIGIN/../$$LIB'
+ BIN_LDLIBS         = -l:$(LIB_SHARED) -lcap $(LDLIBS)
+ 
++ifeq ($(WITH_TIRPC), yes)
++BIN_CPPFLAGS       += -isystem $(DEPS_DIR)$(includedir)/tirpc -DWITH_TIRPC
++endif
++
+ $(word 1,$(LIB_RPC_SRCS)): RPCGENFLAGS=-h
+ $(word 2,$(LIB_RPC_SRCS)): RPCGENFLAGS=-c
+ $(word 3,$(LIB_RPC_SRCS)): RPCGENFLAGS=-m
+@@ -218,12 +223,12 @@ static: $(LIB_STATIC)($(LIB_STATIC_OBJ))
+ deps: export DESTDIR:=$(DEPS_DIR)
+ deps: $(LIB_RPC_SRCS) $(BUILD_DEFS)
+ 	$(MKDIR) -p $(DEPS_DIR)
+-	$(MAKE) -f $(MAKE_DIR)/nvidia-modprobe.mk install
++	$(MAKE) -f $(MAKE_DIR)/nvidia-modprobe.mk DESTDIR=$(DEPS_DIR) install
+ ifeq ($(WITH_LIBELF), no)
+-	$(MAKE) -f $(MAKE_DIR)/elftoolchain.mk install
++	$(MAKE) -f $(MAKE_DIR)/elftoolchain.mk DESTDIR=$(DEPS_DIR) install
+ endif
+ ifeq ($(WITH_TIRPC), yes)
+-	$(MAKE) -f $(MAKE_DIR)/libtirpc.mk install
++	$(MAKE) -f $(MAKE_DIR)/libtirpc.mk DESTDIR=$(DEPS_DIR) install
+ endif
+ 
+ install: all
+-- 
+2.23.0
+

--- a/recipes-containers/libnvidia-container-tools/libnvidia-container-tools_1.0.6.bb
+++ b/recipes-containers/libnvidia-container-tools/libnvidia-container-tools_1.0.6.bb
@@ -36,17 +36,11 @@ LIBTIRPC_VERSION = "1.1.4"
 SRC_URI = " \
     git://github.com/NVIDIA/libnvidia-container.git;name=libnvidia \
     https://github.com/NVIDIA/nvidia-modprobe/archive/${NVIDIA_MODPROBE_VERSION}.tar.gz;name=modprobe \
-    https://sourceforge.net/projects/elftoolchain/files/Sources/elftoolchain-${ELF_TOOLCHAIN_VERSION}/elftoolchain-${ELF_TOOLCHAIN_VERSION}.tar.bz2;name=elftoolchain \
-    https://downloads.sourceforge.net/project/libtirpc/libtirpc/${LIBTIRPC_VERSION}/libtirpc-${LIBTIRPC_VERSION}.tar.bz2;name=libtirpc \
     file://0001-Makefile-Fix-RCP-flags-and-change-prefix.patch \
 "
 
-SRC_URI[elftoolchain.md5sum] = "47fe4cedded2edeaf8e429f1f842e23d"
-SRC_URI[elftoolchain.sha256sum] = "44f14591fcf21294387215dd7562f3fb4bec2f42f476cf32420a6bbabb2bd2b5"
 SRC_URI[modprobe.md5sum] = "f82b649e7a0f1d1279264f9494e7cf43"
 SRC_URI[modprobe.sha256sum] = "25bc6437a384be670e9fd76ac2e5b9753517e23eb16e7fa891b18537b70c4b20"
-SRC_URI[libtirpc.md5sum] = "f5d2a623e9dfbd818d2f3f3a4a878e3a"
-SRC_URI[libtirpc.sha256sum] = "2ca529f02292e10c158562295a1ffd95d2ce8af97820e3534fe1b0e3aec7561d"
 
 
 SRCREV = "b6aff41f09bb2c21ed7da3058c61a063726fa5d6"
@@ -67,13 +61,6 @@ do_configure_append() {
     # Mark Nvidia modprobe as downloaded
     cp -r ${WORKDIR}/nvidia-modprobe-${NVIDIA_MODPROBE_VERSION} ${S}/deps/src
     touch ${S}/deps/src/nvidia-modprobe-${NVIDIA_MODPROBE_VERSION}/.download_stamp
-    # Mark elftoolchain as downloaded
-    cp -r ${WORKDIR}/elftoolchain-${ELF_TOOLCHAIN_VERSION} ${S}/deps/src
-    touch ${S}/deps/src/elftoolchain-${ELF_TOOLCHAIN_VERSION}/.download_stamp
-    # Mark libtirpc as downloaded
-    cp -r ${WORKDIR}/libtirpc-${LIBTIRPC_VERSION} ${S}/deps/src
-    touch ${S}/deps/src/libtirpc-${LIBTIRPC_VERSION}/.download_stamp
-
 }
 
 do_install () {

--- a/recipes-containers/libnvidia-container-tools/libnvidia-container-tools_1.0.6.bb
+++ b/recipes-containers/libnvidia-container-tools/libnvidia-container-tools_1.0.6.bb
@@ -1,0 +1,83 @@
+SUMMARY = "NVIDIA container runtime library"
+
+DESCRIPTION = "NVIDIA container runtime library \
+The nvidia-container library provides an interface to configure GNU/Linux \
+containers leveraging NVIDIA hardware. The implementation relies on several \
+kernel subsystems and is designed to be agnostic of the container runtime. \
+"
+
+HOMEPAGE = "https://github.com/NVIDIA/libnvidia-container"
+
+DEPENDS = " \
+    coreutils-native \
+    pkgconfig-native \
+    libcap \
+    elfutils \
+    libtirpc \
+    libseccomp \
+    ldconfig-native \
+"
+LICENSE = "GPLv3 & Apache-2.0"
+
+LIC_FILES_CHKSUM = "\
+    file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57 \
+    file://COPYING;md5=1ebbd3e34237af26da5dc08a4e440464 \
+    file://COPYING.LESSER;md5=3000208d539ec061b899bce1d9ce9404 \
+"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}-${PV}:"
+
+PR = "r1"
+
+NVIDIA_MODPROBE_VERSION = "396.51"
+ELF_TOOLCHAIN_VERSION = "0.7.1"
+LIBTIRPC_VERSION = "1.1.4"
+
+SRC_URI = " \
+    git://github.com/NVIDIA/libnvidia-container.git;name=libnvidia \
+    https://github.com/NVIDIA/nvidia-modprobe/archive/${NVIDIA_MODPROBE_VERSION}.tar.gz;name=modprobe \
+    https://sourceforge.net/projects/elftoolchain/files/Sources/elftoolchain-${ELF_TOOLCHAIN_VERSION}/elftoolchain-${ELF_TOOLCHAIN_VERSION}.tar.bz2;name=elftoolchain \
+    https://downloads.sourceforge.net/project/libtirpc/libtirpc/${LIBTIRPC_VERSION}/libtirpc-${LIBTIRPC_VERSION}.tar.bz2;name=libtirpc \
+    file://0001-Makefile-Fix-RCP-flags-and-change-prefix.patch \
+"
+
+SRC_URI[elftoolchain.md5sum] = "47fe4cedded2edeaf8e429f1f842e23d"
+SRC_URI[elftoolchain.sha256sum] = "44f14591fcf21294387215dd7562f3fb4bec2f42f476cf32420a6bbabb2bd2b5"
+SRC_URI[modprobe.md5sum] = "f82b649e7a0f1d1279264f9494e7cf43"
+SRC_URI[modprobe.sha256sum] = "25bc6437a384be670e9fd76ac2e5b9753517e23eb16e7fa891b18537b70c4b20"
+SRC_URI[libtirpc.md5sum] = "f5d2a623e9dfbd818d2f3f3a4a878e3a"
+SRC_URI[libtirpc.sha256sum] = "2ca529f02292e10c158562295a1ffd95d2ce8af97820e3534fe1b0e3aec7561d"
+
+
+SRCREV = "b6aff41f09bb2c21ed7da3058c61a063726fa5d6"
+
+S = "${WORKDIR}/git"
+
+# We need to link with libelf, otherwise we need to
+# include bmake-native which does not exist at the moment.
+EXTRA_OEMAKE_append = " WITH_LIBELF=yes"
+
+CFLAGS_prepend = " -I ${WORKDIR}/recipe-sysroot/usr/include/tirpc "
+
+export OBJCPY="${OBJCOPY}"
+
+# Fix me: Create an independent recipe for nvidia-modprobe
+do_configure_append() {
+    mkdir -p ${S}/deps/src
+    # Mark Nvidia modprobe as downloaded
+    cp -r ${WORKDIR}/nvidia-modprobe-${NVIDIA_MODPROBE_VERSION} ${S}/deps/src
+    touch ${S}/deps/src/nvidia-modprobe-${NVIDIA_MODPROBE_VERSION}/.download_stamp
+    # Mark elftoolchain as downloaded
+    cp -r ${WORKDIR}/elftoolchain-${ELF_TOOLCHAIN_VERSION} ${S}/deps/src
+    touch ${S}/deps/src/elftoolchain-${ELF_TOOLCHAIN_VERSION}/.download_stamp
+    # Mark libtirpc as downloaded
+    cp -r ${WORKDIR}/libtirpc-${LIBTIRPC_VERSION} ${S}/deps/src
+    touch ${S}/deps/src/libtirpc-${LIBTIRPC_VERSION}/.download_stamp
+
+}
+
+do_install () {
+    oe_runmake install DESTDIR=${D} 
+}
+
+INSANE_SKIP_${PN}_append = "already-stripped"

--- a/recipes-containers/libnvidia-container-tools/libnvidia-container-tools_1.0.6.bb
+++ b/recipes-containers/libnvidia-container-tools/libnvidia-container-tools_1.0.6.bb
@@ -35,7 +35,7 @@ LIBTIRPC_VERSION = "1.1.4"
 
 SRC_URI = " \
     git://github.com/NVIDIA/libnvidia-container.git;name=libnvidia \
-    https://github.com/NVIDIA/nvidia-modprobe/archive/${NVIDIA_MODPROBE_VERSION}.tar.gz;name=modprobe \
+    git://github.com/NVIDIA/nvidia-modprobe.git;name=modprobe;destsuffix=git/deps/src/nvidia-modprobe-${NVIDIA_MODPROBE_VERSION} \
     file://0001-Makefile-Fix-RCP-flags-and-change-prefix.patch \
 "
 
@@ -43,7 +43,9 @@ SRC_URI[modprobe.md5sum] = "f82b649e7a0f1d1279264f9494e7cf43"
 SRC_URI[modprobe.sha256sum] = "25bc6437a384be670e9fd76ac2e5b9753517e23eb16e7fa891b18537b70c4b20"
 
 
-SRCREV = "b6aff41f09bb2c21ed7da3058c61a063726fa5d6"
+SRCREV_libnvidia = "b6aff41f09bb2c21ed7da3058c61a063726fa5d6"
+# Nvidia modprobe version 396.51
+SRCREV_modprobe = "d97c08af5061f1516fb2e3a26508936f69d6d71d"
 
 S = "${WORKDIR}/git"
 
@@ -57,9 +59,7 @@ export OBJCPY="${OBJCOPY}"
 
 # Fix me: Create an independent recipe for nvidia-modprobe
 do_configure_append() {
-    mkdir -p ${S}/deps/src
     # Mark Nvidia modprobe as downloaded
-    cp -r ${WORKDIR}/nvidia-modprobe-${NVIDIA_MODPROBE_VERSION} ${S}/deps/src
     touch ${S}/deps/src/nvidia-modprobe-${NVIDIA_MODPROBE_VERSION}/.download_stamp
 }
 


### PR DESCRIPTION
Signed-off-by: Pablo Rodriguez Quesada <pablo.rodriguez-quesada@windriver.com>

Add recipe of libnvidia-container-tools for yocto in recipes-containers.
Tested on Wind River Linux LTS19 equivalent to Yocto Zeus 3.0.

To do: separate nvidia modprobe.