### PR TITLE
Fix RPROVIDES for libgl* packages

### DIFF
--- a/recipes-graphics/libglvnd/libglvnd_1.2.0.bb
+++ b/recipes-graphics/libglvnd/libglvnd_1.2.0.bb
@@ -44,3 +44,5 @@ do_install_append() {
         sed -i -e 's|^Cflags: .*|& -DEGL_NO_X11|g' ${D}${libdir}/pkgconfig/libglvnd.pc ${D}${libdir}/pkgconfig/egl.pc
     fi
 }
+
+RPROVIDES_${PN} += "libegl libgl libgles1 libgles2"

--- a/recipes-graphics/mesa/mesa_%.bbappend
+++ b/recipes-graphics/mesa/mesa_%.bbappend
@@ -25,3 +25,5 @@ FILES_libegl-mesa += "${libdir}/libEGL_mesa.so.* ${datadir}/glvnd"
 FILES_libegl-mesa-dev += "${libdir}/libEGL_mesa.so"
 FILES_libgl-mesa += "${libdir}/libGLX_mesa.so.*"
 FILES_libgl-mesa-dev += "${libdir}/libGLX_mesa.so"
+
+RPROVIDES_${PN}_tegra += "libgbm"


### PR DESCRIPTION
Fixup RPROVIDES for mesa and libglvnd to avoid issues with packages that
have runtime dependencies on opengl libraries.