### PR TITLE
Add USB device mode support

### DIFF
--- a/external/openembedded-layer/recipes-support/libusbgx/libusbgx-config.bbappend
+++ b/external/openembedded-layer/recipes-support/libusbgx/libusbgx-config.bbappend
@@ -1,0 +1,22 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+
+SRC_URI_append_tegra = " \
+    file://l4t.schema.in \
+    file://usbgx-overrides.conf \
+    file://l4t-gadget-config-setup.sh \
+"
+
+do_install_append_tegra() {
+    install -d ${D}${datadir}/usbgx
+    install -m 0644 ${WORKDIR}/l4t.schema.in ${D}${datadir}/usbgx/
+    install -d ${D}${sysconfdir}/usbgx
+    ln -sf /run/usbgx/l4t.schema ${D}${sysconfdir}/usbgx/
+    install -d ${D}${sysconfdir}/systemd/system/usbgx.service.d
+    install -m 0644 ${WORKDIR}/usbgx-overrides.conf ${D}${sysconfdir}/systemd/system/usbgx.service.d/
+    install -d ${D}${bindir}
+    install -m 0755 ${WORKDIR}/l4t-gadget-config-setup.sh ${D}${bindir}/l4t-gadget-config-setup
+    sed -i -e's,^IMPORT_SCHEMAS=.*,IMPORT_SCHEMAS="l4t",' ${D}${sysconfdir}/default/usbgx
+}
+
+FILES_${PN} += "${datadir}/usbgx"
+PACKAGE_ARCH_tegra = "${MACHINE_ARCH}"

--- a/external/openembedded-layer/recipes-support/libusbgx/libusbgx-config/l4t-gadget-config-setup.sh
+++ b/external/openembedded-layer/recipes-support/libusbgx/libusbgx-config/l4t-gadget-config-setup.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+[ -d /run/usbgx ] || mkdir /run/usbgx
+[ ! -e /run/usbgx/l4t.schema ] || exit 0
+if [ ! -e /usr/share/usbgx/l4t.schema.in ]; then
+    echo "ERR: missing gadget schema template" >&2
+    exit 1
+fi
+sernum=$(cat /proc/device-tree/serial-number 2>/dev/null | tr -d '\000')
+[ -n "$sernum" ] || sernum="UNKNOWN"
+sed -e"s,@SERIALNUMBER@,$sernum," /usr/share/usbgx/l4t.schema.in > /run/usbgx/l4t.schema
+chmod 0644 /run/usbgx/l4t.schema

--- a/external/openembedded-layer/recipes-support/libusbgx/libusbgx-config/l4t.schema.in
+++ b/external/openembedded-layer/recipes-support/libusbgx/libusbgx-config/l4t.schema.in
@@ -1,0 +1,88 @@
+attrs :
+{
+    bcdUSB = 0x210;
+    bDeviceClass = 0x0;
+    bDeviceSubClass = 0x0;
+    bDeviceProtocol = 0x0;
+    bMaxPacketSize0 = 0x40;
+    idVendor = 0x1D6B;
+    idProduct = 0x104;
+    bcdDevice = 0x1;
+};
+os_descs :
+{
+    config_id = 1;
+    use = 1;
+    qw_sign = "MSFT100";
+    b_vendor_code = 0xcd;
+};
+strings = (
+    {
+        lang = 0x409;
+        manufacturer = "NVIDIA";
+        product = "Linux for Tegra";
+        serialnumber = "@SERIALNUMBER@";
+    } );
+functions :
+{
+    rndis_usb0 :
+    {
+        instance = "usb0";
+        type = "rndis";
+        attrs :
+        {
+        };
+        os_descs = (
+            {
+                interface = "rndis";
+                compatible_id = "RNDIS";
+                sub_compatible_id = "5162001";
+            } );
+    };
+    acm_usb0 :
+    {
+        instance = "usb0";
+        type = "acm";
+        attrs :
+        {
+        };
+        os_descs = ( );
+    };
+    ecm_usb0 :
+    {
+        instance = "usb0";
+        type = "ecm";
+        attrs :
+        {
+        };
+        os_descs = ( );
+    };
+};
+configs = (
+    {
+        id = 1;
+        name = "L4T";
+        attrs :
+        {
+            bmAttributes = 0x80;
+            bMaxPower = 0x2;
+        };
+        strings = (
+            {
+                lang = 0x409;
+                configuration = "CDC RNDIS+ACM+ECM";
+            } );
+        functions = (
+            {
+                name = "rndis.usb0";
+                function = "rndis_usb0";
+            },
+            {
+                name = "acm.GS0";
+                function = "acm_usb0";
+            },
+            {
+                name = "ecm.usb0";
+                function = "ecm_usb0";
+            } );
+    } );

--- a/external/openembedded-layer/recipes-support/libusbgx/libusbgx-config/usbgx-overrides.conf
+++ b/external/openembedded-layer/recipes-support/libusbgx/libusbgx-config/usbgx-overrides.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecStartPre=/usr/bin/l4t-gadget-config-setup

--- a/external/openembedded-layer/recipes-support/libusbgx/libusbgx/usb-gadget.target
+++ b/external/openembedded-layer/recipes-support/libusbgx/libusbgx/usb-gadget.target
@@ -1,0 +1,12 @@
+#  SPDX-License-Identifier: LGPL-2.1+
+#
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+[Unit]
+Description=Hardware activated USB gadget
+Documentation=man:systemd.special(7)

--- a/external/openembedded-layer/recipes-support/libusbgx/libusbgx_%.bbappend
+++ b/external/openembedded-layer/recipes-support/libusbgx/libusbgx_%.bbappend
@@ -1,0 +1,18 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+
+SRC_URI_append_tegra = " \
+    file://usb-gadget.target \
+"
+
+do_install_append_tegra() {
+    sed -i -e's,^WantedBy=.*,WantedBy=usb-gadget.target,' ${D}${systemd_system_unitdir}/usbgx.service
+    install -m 0644 ${WORKDIR}/usb-gadget.target ${D}${systemd_system_unitdir}/
+}
+
+SYSTEMD_SERVICE_${PN}_append_tegra = " usb-gadget.target"
+PACKAGES_prepend_tegra = "${PN}-examples "
+FILES_${PN}-examples = "${bindir}/gadget-acm-ecm ${bindir}/gadget-export ${bindir}/gadget-ffs \
+                        ${bindir}/gadget-hid ${bindir}/gadget-midi ${bindir}/gadget-ms \
+                        ${bindir}/gadget-rndis-os-desc ${bindir}/gadget-uac2"
+RRECOMMENDS_${PN}_append_tegra = " kernel-module-tegra-xudc"
+PACKAGE_ARCH_tegra = "${SOC_FAMILY_PKGARCH}"

--- a/recipes-bsp/l4t-usb-device-mode/l4t-usb-device-mode.bb
+++ b/recipes-bsp/l4t-usb-device-mode/l4t-usb-device-mode.bb
@@ -1,0 +1,30 @@
+DESCRIPTION = "Configuration for setting up L4T USB device mode gadgets"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = "\
+    file://70-l4t-usb-gadget.network \
+    file://70-l4tbr0.network \
+    file://l4tbr0.netdev \
+    file://98-usb-gadget-tty.rules \
+"
+
+COMPATIBLE_MACHINE = "(tegra)"
+REQUIRED_DISTRO_FEATURES = "systemd"
+
+S = "${WORKDIR}"
+
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
+
+do_install() {
+    install -d ${D}${sysconfdir}/systemd/network
+    install -m 0644 ${S}/l4tbr0.netdev ${D}${sysconfdir}/systemd/network/
+    install -m 0644 ${S}/70-l4tbr0.network ${D}${sysconfdir}/systemd/network/
+    install -m 0644 ${S}/70-l4t-usb-gadget.network ${D}${sysconfdir}/systemd/network/
+    install -d ${D}${sysconfdir}/udev/rules.d
+    install -m 0644 ${S}/98-usb-gadget-tty.rules ${D}${sysconfdir}/udev/rules.d/
+}
+
+RDEPENDS_${PN} = "libusbgx"
+

--- a/recipes-bsp/l4t-usb-device-mode/l4t-usb-device-mode/70-l4t-usb-gadget.network
+++ b/recipes-bsp/l4t-usb-device-mode/l4t-usb-device-mode/70-l4t-usb-gadget.network
@@ -1,0 +1,6 @@
+[Match]
+Name=usb* rndis*
+Type=gadget
+
+[Network]
+Bridge=l4tbr0

--- a/recipes-bsp/l4t-usb-device-mode/l4t-usb-device-mode/70-l4tbr0.network
+++ b/recipes-bsp/l4t-usb-device-mode/l4t-usb-device-mode/70-l4tbr0.network
@@ -1,0 +1,16 @@
+[Match]
+Name=l4tbr0
+
+[Network]
+Address=192.168.55.1/24
+DHCPServer=yes
+
+[DHCPServer]
+PoolOffset=99
+PoolSize=1
+DefaultLeaseTime=900
+
+[Route]
+Gateway=192.168.55.100
+GatewayOnLink=yes
+Metric=32766

--- a/recipes-bsp/l4t-usb-device-mode/l4t-usb-device-mode/98-usb-gadget-tty.rules
+++ b/recipes-bsp/l4t-usb-device-mode/l4t-usb-device-mode/98-usb-gadget-tty.rules
@@ -1,0 +1,2 @@
+SUBSYSTEM=="tty", KERNEL=="ttyGS[0-9]", ACTION=="add", RUN+="/bin/systemctl start serial-getty@%k.service"
+SUBSYSTEM=="tty", KERNEL=="ttyGS[0-9]", ACTION=="remove", RUN+="/bin/systemctl stop serial-getty@%k.service"

--- a/recipes-bsp/l4t-usb-device-mode/l4t-usb-device-mode/l4tbr0.netdev
+++ b/recipes-bsp/l4t-usb-device-mode/l4t-usb-device-mode/l4tbr0.netdev
@@ -1,0 +1,3 @@
+[NetDev]
+Name=l4tbr0
+Kind=bridge


### PR DESCRIPTION
Implement a subset of the USB device mode support provided in L4T - just the NCM and RNDIS networking gadgets and the ACM (serial tty) device.

The implementation here uses `libusbgx` from the `meta-oe` layer, so you must have that layer (or recipes for `libusbgx` and its dependencies) in your build.

For the networking support, systemd-networkd configuration files are provided.