### PR TITLE
setup-nv-boot-control: fixed the sysvinit build

### DIFF
--- a/recipes-bsp/tools/setup-nv-boot-control_1.0.bb
+++ b/recipes-bsp/tools/setup-nv-boot-control_1.0.bb
@@ -48,4 +48,7 @@ SYSTEMD_SERVICE_${PN}-service = "setup-nv-boot-control.service"
 RDEPENDS_${PN}-service = "${PN}"
 RDEPENDS_${PN} = "tegra-nv-boot-control-config tegra-eeprom-tool-boardspec"
 
+FILES_${PN} = "${bindir}/setup-nv-boot-control"
+FILES_${PN}-service = "${sysconfdir} ${systemd_system_unitdir}"
+
 PACKAGE_ARCH = "${MACHINE_ARCH}"


### PR DESCRIPTION
When building an image with sysvinit, the final build step results in an error: "mender-tegra-bup-payload-install missing". This fix makes sure for a sysvinit build that the "setup-nv-boot-control-service" package also contains a file. Otherwise this package will not be created resulting in a failure since "mender-tegra-bup-payload-install" is in the end dependent on this package.

Signed-off-by: Boris Nagels <develop@focusware.nl>