### PR TITLE
tegra186-flashtools-native: make NVIDIA_DEVNET_MIRROR optional

### DIFF
--- a/README
+++ b/README
@@ -33,6 +33,14 @@ PLEASE NOTE
   (e.g., local.conf) to make them available to your bitbake
   builds.
 
+  For Jetson-TX2 builds, you must also **manually** download
+  the [Jetson Platform Fuse Burning and Secure Boot Documentation
+  and Tools](http://developer.nvidia.com/embedded/dlc/jetson-fuse-burning-secure-boot-32-1)
+  package, as this package is not distributed through the
+  NVIDIA SDK Manager. If NVIDIA_DEVNET_MIRROR is not set
+  in your build configuration, you can omit this step
+  and image signing support will be excluded.
+
 * The SDK Manager downloads a different package of CUDA host-side
   tools depending on whether you are running Ubuntu 16.04
   or 18.04. If you downloaded the Ubuntu 16.04 package, you

--- a/classes/nvidia_devnet_downloads.bbclass
+++ b/classes/nvidia_devnet_downloads.bbclass
@@ -1,9 +1,15 @@
 NVIDIA_DEVNET_MIRROR ??= "file://NOTDEFINED"
 SRC_URI[vardepsexclude] += "NVIDIA_DEVNET_MIRROR"
+NVIDIA_DEVNET_OPTIONAL ??= "0"
 
 python () {
+    if bb.utils.to_boolean(d.getVar('NVIDIA_DEVNET_OPTIONAL', False)):
+        if d.getVar('NVIDIA_DEVNET_MIRROR') == 'file://NOTDEFINED':
+            d.setVar('HAVE_DEVNET_MIRROR', '0')
+            return
     if d.getVar('NVIDIA_DEVNET_MIRROR') == 'file://NOTDEFINED':
         raise bb.parse.SkipRecipe("Recipe requires NVIDIA_DEVNET_MIRROR setup")
+    d.setVar('HAVE_DEVNET_MIRROR', '1')
     if not d.getVar('NVIDIA_DEVNET_MIRROR').startswith('file://'):
         return
     # XXX

--- a/recipes-bsp/tegra-binaries/tegra-binaries-32.1.0.inc
+++ b/recipes-bsp/tegra-binaries/tegra-binaries-32.1.0.inc
@@ -3,7 +3,7 @@ LIC_FILES_CHKSUM = "file://nv_tegra/LICENSE;md5=2cc00be68c1227a7c42ff3620ef75d05
                     file://nv_tegra/LICENSE.brcm_patchram_plus;md5=38fb07f0dacf4830bc57f40a0fb7532e"
 
 SRC_URI = "${L4T_URI_BASE}/${L4T_BSP_PREFIX}_Linux_R${PV}_aarch64.tbz2;name=l4t ${SRC_URI_SECUREBOOT}"
-SRC_URI_SECUREBOOT = "${NVIDIA_DEVNET_MIRROR}/secureboot_r32.1.tbz2;name=sb"
+SRC_URI_SECUREBOOT = "${@oe.utils.conditional('HAVE_DEVNET_MIRROR', '1', '${NVIDIA_DEVNET_MIRROR}/secureboot_r32.1.tbz2;name=sb', '', d)}"
 # L4T 32.1 does not support Jetson Nano/TX1 secureboot
 SRC_URI_SECUREBOOT_tegra210 = ""
 L4T_MD5SUM = "881fedee06a7446953a064b574227980"
@@ -17,7 +17,8 @@ SRC_URI[l4t.sha256sum] = "${L4T_SHA256SUM}"
 SRC_URI[sb.md5sum] = "${SB_MD5SUM}"
 SRC_URI[sb.sha256sum] = "${SB_SHA256SUM}"
 
-inherit l4t_bsp
+NVIDIA_DEVNET_OPTIONAL = "1"
+inherit l4t_bsp nvidia_devnet_downloads
 
 SRC_URI += "\
     file://nvargus-daemon.init \

--- a/recipes-bsp/tegra-binaries/tegra186-flashtools-native_32.1.0.bb
+++ b/recipes-bsp/tegra-binaries/tegra186-flashtools-native_32.1.0.bb
@@ -20,8 +20,7 @@ SRC_URI += "file://nvargus-daemon.init \
            file://tegra186-flash-helper.sh \
            file://tegra194-flash-helper.sh \
            file://tegra210-flash-helper.sh \
-           file://0001-Fix-skipuid-arg-usage-for-tx2-in-odmsign.func.patch \
-           file://0002-Update-l4t_bup_gen.func-to-handle-signed-encrypted-b.patch \
+           ${@oe.utils.conditional('HAVE_DEVNET_MIRROR', '1', 'file://0001-Fix-skipuid-arg-usage-for-tx2-in-odmsign.func.patch file://0002-Update-l4t_bup_gen.func-to-handle-signed-encrypted-b.patch', '', d)} \
            "
 S = "${WORKDIR}/Linux_for_Tegra"
 B = "${WORKDIR}/build"
@@ -59,15 +58,17 @@ do_install() {
     install -m 0755 ${S}/bootloader/rollback/rollback_parser.py ${D}${BINDIR}
     sed -i -e's,^#!/usr/bin/python,#!/usr/bin/env python,' ${D}${BINDIR}/rollback_parser.py
     install -m 0644 ${S}/bootloader/l4t_bup_gen.func ${D}${BINDIR}
-    install -m 0644 ${S}/bootloader/odmsign.func ${D}${BINDIR}
 
     install -m 0755 ${S}/bootloader/mkgpt ${D}${BINDIR}
     install -m 0755 ${S}/bootloader/mksparse ${D}${BINDIR}
     install -m 0755 ${S}/bootloader/mkbootimg ${D}${BINDIR}
-    install -d ${D}${BINDIR}/pkc
-    install -m 0755 ${S}/pkc/mkpkc ${D}${BINDIR}/pkc/
-    install -m 0755 ${S}/pkc/nvsecuretool ${D}${BINDIR}/pkc/
-    install -m 0755 ${S}/bootloader/tegrakeyhash ${D}${BINDIR}
+    if ${@oe.utils.conditional('HAVE_DEVNET_MIRROR', '1', 'true', 'false', d)}; then
+        install -m 0644 ${S}/bootloader/odmsign.func ${D}${BINDIR}
+        install -d ${D}${BINDIR}/pkc
+        install -m 0755 ${S}/pkc/mkpkc ${D}${BINDIR}/pkc/
+        install -m 0755 ${S}/pkc/nvsecuretool ${D}${BINDIR}/pkc/
+        install -m 0755 ${S}/bootloader/tegrakeyhash ${D}${BINDIR}
+    fi
     install -m 0755 ${S}/tegra186-flash-helper.sh ${D}${BINDIR}
     install -m 0755 ${S}/tegra194-flash-helper.sh ${D}${BINDIR}
 }


### PR DESCRIPTION
For builds not requiring secure boot support on tegra186
platforms, skip downloading the secureboot package if
NVIDIA_DEVNET_MIRROR is not defined.

[Fixes #284]

Signed-off-by: Matt Madison <matt@madison.systems>