### PR TITLE
jetson-xavier-8gb: drop unused MACHINEOVERRIDES 'xavier-8gb'

### DIFF
--- a/conf/machine/jetson-xavier-8gb.conf
+++ b/conf/machine/jetson-xavier-8gb.conf
@@ -14,5 +14,3 @@ TEGRA_BUPGEN_SPECS ?= "fab=400;boardsku=0006;boardrev=B.0"
 NVPMODEL ?= "nvpmodel_t194_8gb"
 
 include conf/machine/jetson-xavier.conf
-
-MACHINEOVERRIDES .= ":xavier-8gb"


### PR DESCRIPTION
This was used originally to identify this machine variant in the
tegra-nvpmodel build, but the NVPMODEL variable has since been
added to the machine definition itself, so this is no longer required.