### PR TITLE
libdrm-nvdc: extend DEBIAN_NOAUTONAME to -dev, -dbg packages

### DIFF
--- a/recipes-bsp/tegra-binaries/libdrm-nvdc_32.3.1.bb
+++ b/recipes-bsp/tegra-binaries/libdrm-nvdc_32.3.1.bb
@@ -23,6 +23,8 @@ do_install() {
 }
 
 DEBIAN_NOAUTONAME_${PN} = "1"
+DEBIAN_NOAUTONAME_${PN}-dev = "1"
+DEBIAN_NOAUTONAME_${PN}-dbg = "1"
 FILES_${PN} = "${libdir} ${sysconfdir}/ld.so.conf.d"
 FILES_${PN}-dev = ""
 PRIVATE_LIBS = "libdrm.so.2"


### PR DESCRIPTION
to avoid conflicts with the real libdrm's packages.

Signed-off-by: Matt Madison <matt@madison.systems>

Fixes #290