### PR TITLE
Bug/include camera modules4tx2

### DIFF
--- a/conf/machine/jetson-tx2.conf
+++ b/conf/machine/jetson-tx2.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/tegra186.inc
 
-MACHINE_EXTRA_RRECOMMENDS += "tegra-firmware-brcm kernel-module-bcmdhd"
+MACHINE_EXTRA_RRECOMMENDS += "tegra-firmware-brcm kernel-module-bcmdhd kernel-module-ov5693"
 
 KERNEL_DEVICETREE ?= "_ddot_/_ddot_/_ddot_/_ddot_/nvidia/platform/t18x/quill/kernel-dts/tegra186-quill-p3310-1000-c03-00-base.dtb"
 KERNEL_ARGS ?= "console=ttyS0,115200 console=tty0 OS=l4t fbcon=map:0"


### PR DESCRIPTION
Added kernel modules for omnivision on board camera for jetson tx2 in jetson-tx2 machine configuration.