### PR TITLE
Update tegraflash packaging for BUP generation and other enhancements

### DIFF
--- a/classes/image_types_tegra.bbclass
+++ b/classes/image_types_tegra.bbclass
@@ -295,7 +295,10 @@ create_tegraflash_pkg_tegra210() {
         boardcfg=
     fi
 
-    [ "${TEGRA_SIGNING_EXCLUDE_TOOLS}" = "1" ] || cp -R ${STAGING_BINDIR_NATIVE}/tegra210-flash/* .
+    if [ "${TEGRA_SIGNING_EXCLUDE_TOOLS}" != "1" ]; then
+        cp -R ${STAGING_BINDIR_NATIVE}/tegra210-flash/* .
+        tegraflash_generate_bupgen_script
+    fi
     tegraflash_custom_pre
     ln -s "${IMAGE_TEGRAFLASH_ROOTFS}" ./${IMAGE_BASENAME}.${IMAGE_TEGRAFLASH_FS_TYPE}
     tegraflash_create_flash_config "${WORKDIR}/tegraflash" ${LNXFILE}
@@ -364,7 +367,11 @@ create_tegraflash_pkg_tegra186() {
             ln -sf $fname ./
         done
     done
-    [ "${TEGRA_SIGNING_EXCLUDE_TOOLS}" = "1" ] || cp -R ${STAGING_BINDIR_NATIVE}/tegra186-flash/* .
+    if [ "${TEGRA_SIGNING_EXCLUDE_TOOLS}" != "1" ]; then
+        cp -R ${STAGING_BINDIR_NATIVE}/tegra186-flash/* .
+        mv ./rollback_parser.py ./rollback/
+        tegraflash_generate_bupgen_script
+    fi
     dd if=/dev/zero of=badpage.bin bs=4096 count=1
     if [ -e ${STAGING_DATADIR}/tegraflash/odmfuse_pkc_${MACHINE}.xml ]; then
         cp ${STAGING_DATADIR}/tegraflash/odmfuse_pkc_${MACHINE}.xml ./odmfuse_pkc.xml
@@ -428,7 +435,11 @@ create_tegraflash_pkg_tegra194() {
     for f in ${STAGING_DATADIR}/tegraflash/tegra194-*-bpmp-*.dtb; do
         ln -s $f .
     done
-    [ "${TEGRA_SIGNING_EXCLUDE_TOOLS}" = "1" ] || cp -R ${STAGING_BINDIR_NATIVE}/tegra186-flash/* .
+    if [ "${TEGRA_SIGNING_EXCLUDE_TOOLS}" != "1" ]; then
+        cp -R ${STAGING_BINDIR_NATIVE}/tegra186-flash/* .
+        mv ./rollback_parser.py ./rollback/
+        tegraflash_generate_bupgen_script
+    fi
     tegraflash_custom_pre
     mksparse -v --fillpattern=0 "${IMAGE_TEGRAFLASH_ROOTFS}" ${IMAGE_BASENAME}.img
     tegraflash_create_flash_config "${WORKDIR}/tegraflash" ${LNXFILE}
@@ -446,6 +457,35 @@ END
     cd $oldwd
 }
 create_tegraflash_pkg[vardepsexclude] += "DATETIME"
+
+tegraflash_generate_bupgen_script() {
+    local outfile="${1:-./generate_bup_payload.sh}"
+    local spec__ sdramcfg fab boardsku boardrev
+    rm -f $outfile
+    cat <<EOF > $outfile
+#!/bin/bash
+rm -rf signed multi_signed rollback.bin ${BUP_PAYLOAD_DIR}
+export BOARDID=${TEGRA_BOARDID}
+export fuselevel=fuselevel_production
+export localbootfile=${LNXFILE}
+export CHIPREV=${TEGRA_CHIPREV}
+EOF
+    if [ "${SOC_FAMILY}" = "tegra194" ]; then
+        sdramcfg="${MACHINE}.cfg,${MACHINE}-override.cfg"
+    else
+        sdramcfg="${MACHINE}.cfg"
+    fi
+    fab="${TEGRA_FAB}"
+    boardsku="${TEGRA_BOARDSKU}"
+    boardrev="${TEGRA_BOARDREV}"
+    for spec__ in ${@' '.join(['"%s"' % entry for entry in d.getVar('TEGRA_BUPGEN_SPECS').split()])}; do
+	eval $spec__
+        cat <<EOF >> $outfile
+MACHINE=${MACHINE} FAB="$fab" BOARDSKU="$boardsku" BOARDREV="$boardrev" ./${SOC_FAMILY}-flash-helper.sh --bup ./flash.xml.in ${DTBFILE} $sdramcfg ${ODMDATA} "\$@"
+EOF
+    done
+    chmod +x $outfile
+}
 
 IMAGE_CMD_tegraflash = "create_tegraflash_pkg"
 do_image_tegraflash[depends] += "zip-native:do_populate_sysroot dtc-native:do_populate_sysroot \
@@ -535,28 +575,7 @@ oe_make_bup_payload() {
         ln -sf ${STAGING_BINDIR_NATIVE}/${FLASHTOOLS_DIR}/${SOC_FAMILY}-flash-helper.sh ./
         sed -e 's,^function ,,' ${STAGING_BINDIR_NATIVE}/${FLASHTOOLS_DIR}/l4t_bup_gen.func > ./l4t_bup_gen.func
         ln -sf ${STAGING_BINDIR_NATIVE}/${FLASHTOOLS_DIR}/*.py .
-        rm -f ./doflash.sh
-        cat <<EOF > ./doflash.sh
-export BOARDID=${TEGRA_BOARDID}
-export fuselevel=fuselevel_production
-export localbootfile=${LNXFILE}
-export CHIPREV=${TEGRA_CHIPREV}
-EOF
-        if [ "${SOC_FAMILY}" = "tegra194" ]; then
-            sdramcfg="${MACHINE}.cfg,${MACHINE}-override.cfg"
-        else
-            sdramcfg="${MACHINE}.cfg"
-        fi
-	fab="${TEGRA_FAB}"
-	boardsku="${TEGRA_BOARDSKU}"
-	boardrev="${TEGRA_BOARDREV}"
-	for spec__ in ${@' '.join(['"%s"' % entry for entry in d.getVar('TEGRA_BUPGEN_SPECS').split()])}; do
-	    eval $spec__
-            cat <<EOF >>./doflash.sh
-MACHINE=${MACHINE} FAB="$fab" BOARDSKU="$boardsku" BOARDREV="$boardrev" ./${SOC_FAMILY}-flash-helper.sh --bup ./flash.xml.in ${DTBFILE} $sdramcfg ${ODMDATA} "\$@"
-EOF
-	done
-        chmod +x ./doflash.sh
+	tegraflash_generate_bupgen_script ./doflash.sh
     fi
     tegraflash_custom_sign_bup
     mv ${WORKDIR}/bup-payload/${BUP_PAYLOAD_DIR}/* .

--- a/classes/image_types_tegra.bbclass
+++ b/classes/image_types_tegra.bbclass
@@ -597,6 +597,6 @@ create_bup_payload_image() {
 create_bup_payload_image[vardepsexclude] += "DATETIME"
 
 CONVERSIONTYPES += "bup-payload"
-CONVERSION_DEPENDS_bup-payload = "${SOC_FAMILY}-flashtools-native coreutils-native tegra-bootfiles tegra-redundant-boot-base nv-tegra-release dtc-native virtual/bootloader:do_deploy virtual/kernel:do_deploy virtual/secure-os:do_deploy ${TEGRA_SIGNING_EXTRA_DEPS}"
+CONVERSION_DEPENDS_bup-payload = "${SOC_FAMILY}-flashtools-native coreutils-native tegra-bootfiles tegra-redundant-boot-base dtc-native virtual/bootloader:do_deploy virtual/kernel:do_deploy virtual/secure-os:do_deploy ${TEGRA_SIGNING_EXTRA_DEPS}"
 CONVERSION_CMD_bup-payload = "create_bup_payload_image ${type}"
 IMAGE_TYPES += "cpio.gz.cboot.bup-payload"

--- a/classes/image_types_tegra.bbclass
+++ b/classes/image_types_tegra.bbclass
@@ -21,13 +21,13 @@ TEGRA_SIGNING_EXTRA_DEPS ??= ""
 TEGRA_BUPGEN_SPECS ??= "boardid=${TEGRA_BOARDID};fab=${TEGRA_FAB};boardrev=${TEGRA_BOARDREV};chiprev=${TEGRA_CHIPREV}"
 
 DTBFILE ?= "${@os.path.basename(d.getVar('KERNEL_DEVICETREE').split()[0])}"
-LNXFILE ?= "${@'${IMAGE_UBOOT}-${MACHINE}.bin' if '${IMAGE_UBOOT}' != '' else '${KERNEL_IMAGETYPE}-initramfs-${MACHINE}.cboot'}"
+LNXFILE ?= "boot.img"
 LNXSIZE ?= "83886080"
 APPFILE ?= "${@'${IMAGE_BASENAME}.${IMAGE_TEGRAFLASH_FS_TYPE}' if d.getVar('TEGRA_SPIFLASH_BOOT') == '1' else '${IMAGE_BASENAME}.img'}"
 
 IMAGE_TEGRAFLASH_FS_TYPE ??= "ext4"
 IMAGE_TEGRAFLASH_ROOTFS ?= "${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.${IMAGE_TEGRAFLASH_FS_TYPE}"
-IMAGE_TEGRAFLASH_KERNEL ?= "${DEPLOY_DIR_IMAGE}/${LNXFILE}"
+IMAGE_TEGRAFLASH_KERNEL ?= "${DEPLOY_DIR_IMAGE}/${@'${IMAGE_UBOOT}-${MACHINE}.bin' if '${IMAGE_UBOOT}' != '' else '${KERNEL_IMAGETYPE}-initramfs-${MACHINE}.cboot'}"
 
 BL_IS_CBOOT = "${@'1' if d.getVar('PREFERRED_PROVIDER_virtual/bootloader').startswith('cboot') else '0'}"
 TEGRA_SPIFLASH_BOOT ??= ""

--- a/classes/image_types_tegra.bbclass
+++ b/classes/image_types_tegra.bbclass
@@ -587,6 +587,12 @@ create_bup_payload_image() {
     oe_make_bup_payload ${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.${type}
     install -m 0644 ${WORKDIR}/bup-payload/bl_update_payload ${IMGDEPLOYDIR}/${IMAGE_NAME}.bup-payload
     ln -sf ${IMAGE_NAME}.bup-payload ${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.bup-payload
+    for f in ${WORKDIR}/bup-payload/*_only_payload; do
+	[ -e $f ] || continue
+	sfx=$(basename $f _payload)
+	install -m 0644 $f ${IMAGEDEPLOYDIR}/${IMAGE_NAME}.$sfx.bup-payload
+	ln -sf ${IMAGENAME}.$sfx.bup-payload ${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.$sfx.bup-payload
+    done
 }
 create_bup_payload_image[vardepsexclude] += "DATETIME"
 

--- a/classes/image_types_tegra.bbclass
+++ b/classes/image_types_tegra.bbclass
@@ -352,6 +352,11 @@ create_tegraflash_pkg_tegra186() {
     for f in ${BOOTFILES}; do
         ln -s "${STAGING_DATADIR}/tegraflash/$f" .
     done
+    rm -f ./slot_metadata.bin
+    cp ${STAGING_DATADIR}/tegraflash/slot_metadata.bin ./
+    rm -rf ./rollback
+    mkdir ./rollback
+    ln -snf ${STAGING_DATADIR}/nv_tegra/rollback/t${@d.getVar('NVIDIA_CHIP')[2:]}x ./rollback/
     cp ${STAGING_DATADIR}/tegraflash/flashvars .
     . ./flashvars
     for var in $FLASHVARS; do
@@ -420,6 +425,11 @@ create_tegraflash_pkg_tegra194() {
     for f in ${BOOTFILES}; do
         ln -s "${STAGING_DATADIR}/tegraflash/$f" .
     done
+    rm -f ./slot_metadata.bin
+    cp ${STAGING_DATADIR}/tegraflash/slot_metadata.bin ./
+    rm -rf ./rollback
+    mkdir ./rollback
+    ln -snf ${STAGING_DATADIR}/nv_tegra/rollback/t${@d.getVar('NVIDIA_CHIP')[2:]}x ./rollback/
     cp ${STAGING_DATADIR}/tegraflash/flashvars .
     for f in ${STAGING_DATADIR}/tegraflash/tegra19[4x]-*.cfg; do
         ln -s $f .
@@ -450,7 +460,7 @@ IMAGE_CMD_tegraflash = "create_tegraflash_pkg"
 do_image_tegraflash[depends] += "zip-native:do_populate_sysroot dtc-native:do_populate_sysroot \
                                  ${SOC_FAMILY}-flashtools-native:do_populate_sysroot gptfdisk-native:do_populate_sysroot \
                                  tegra-bootfiles:do_populate_sysroot tegra-bootfiles:do_populate_lic \
-                                 virtual/kernel:do_deploy \
+                                 tegra-redundant-boot-base:do_populate_sysroot virtual/kernel:do_deploy \
                                  ${@'${INITRD_IMAGE}:do_image_complete' if d.getVar('INITRD_IMAGE') != '' else  ''} \
                                  ${@'${IMAGE_UBOOT}:do_deploy ${IMAGE_UBOOT}:do_populate_lic' if d.getVar('IMAGE_UBOOT') != '' else  ''} \
                                  cboot:do_deploy virtual/secure-os:do_deploy ${TEGRA_SIGNING_EXTRA_DEPS}"

--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra186-flash-helper.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra186-flash-helper.sh
@@ -4,6 +4,7 @@ keyfile=
 sbk_keyfile=
 no_flash=0
 flash_cmd=
+imgfile=
 
 ARGS=$(getopt -n $(basename "$0") -l "bup,no-flash" -o "u:v:" -- "$@")
 if [ $? -ne 0 ]; then
@@ -51,6 +52,8 @@ dtb_file="$2"
 sdramcfg_file="$3"
 odmdata="$4"
 kernfile="$5"
+imgfile="$6"
+shift 6
 
 here=$(readlink -f $(dirname "$0"))
 flashappname="tegraflash.py"
@@ -153,7 +156,20 @@ date "+%Y%m%d%H%M%S" >>${MACHINE}_bootblob_ver.txt
 bytes=`cksum ${MACHINE}_bootblob_ver.txt | cut -d' ' -f2`
 cksum=`cksum ${MACHINE}_bootblob_ver.txt | cut -d' ' -f1`
 echo "BYTES:$bytes CRC32:$cksum" >>${MACHINE}_bootblob_ver.txt
-sed -e"s,VERFILE,${MACHINE}_bootblob_ver.txt," -e"s,BPFDTB-FILE,$BPFDTB_FILE," "$flash_in" > flash.xml
+appfile_sed=
+if [ "$bup_build" = "yes" ]; then
+    appfile_sed="-e/APPFILE/d"
+elif [ $no_flash -eq 0 ]; then
+    if [ -n "$imgfile" -a -e "$imgfile" ]; then
+	appfile_sed="-es,APPFILE,$imgfile,"
+    else
+	echo "ERR: rootfs image not specified or missing: $imgfile" >&2
+	exit 1
+    fi
+else
+    touch APPFILE
+fi
+sed -e"s,VERFILE,${MACHINE}_bootblob_ver.txt," -e"s,BPFDTB-FILE,$BPFDTB_FILE," $appfile_sed "$flash_in" > flash.xml
 
 BINSARGS="mb2_bootloader nvtboot_recovery.bin; \
 mts_preboot preboot_d15_prod_cr.bin; \
@@ -194,7 +210,7 @@ elif [ -n "$keyfile" ]; then
     SOSARGS="--applet mb1_recovery_prod.bin "
     BCTARGS="$bctargs"
     . "$here/odmsign.func"
-    odmsign_ext || exit 1
+    (odmsign_ext) || exit 1
     if [ $no_flash -ne 0 ]; then
 	if [ -f flashcmd.txt ]; then
 	    chmod +x flashcmd.txt
@@ -202,6 +218,7 @@ elif [ -n "$keyfile" ]; then
 	else
 	    echo "WARN: signing completed successfully, but flashcmd.txt missing" >&2
 	fi
+	rm APPFILE
     fi
     exit 0
 else

--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra194-flash-helper.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra194-flash-helper.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -x
 bup_build=
 keyfile=
 sbk_keyfile=
@@ -121,7 +120,7 @@ else
     board_sku=`$here/chkbdinfo -k ${cvm_bin} | tr -d '[:space:]' | tr [a-z] [A-Z]`
     BOARDSKU="$board_sku"
 fi
-if [ -n "$BOARDREV" ]; then
+if [ "${BOARDREV+isset}" = "isset" ]; then
     board_revision="$BOARDREV"
 else
     board_revision=`$here/chkbdinfo -r ${cvm_bin} | tr -d '[:space:]' | tr [a-z] [A-Z]`

--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra194-flash-helper.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra194-flash-helper.sh
@@ -5,6 +5,7 @@ keyfile=
 sbk_keyfile=
 no_flash=0
 flash_cmd=
+imgfile=
 
 ARGS=$(getopt -n $(basename "$0") -l "bup,no-flash" -o "u:v:" -- "$@")
 if [ $? -ne 0 ]; then
@@ -52,6 +53,8 @@ dtb_file="$2"
 sdramcfg_files="$3"
 odmdata="$4"
 kernfile="$5"
+imgfile="$6"
+shift 6
 
 here=$(readlink -f $(dirname "$0"))
 flashappname="tegraflash.py"
@@ -204,7 +207,20 @@ date "+%Y%m%d%H%M%S" >>${MACHINE}_bootblob_ver.txt
 bytes=`cksum ${MACHINE}_bootblob_ver.txt | cut -d' ' -f2`
 cksum=`cksum ${MACHINE}_bootblob_ver.txt | cut -d' ' -f1`
 echo "BYTES:$bytes CRC32:$cksum" >>${MACHINE}_bootblob_ver.txt
-sed -e"s,VERFILE,${MACHINE}_bootblob_ver.txt," -e"s,BPFDTB_FILE,$BPFDTB_FILE," "$flash_in" > flash.xml
+appfile_sed=
+if [ "$bup_build" = "yes" ]; then
+    appfile_sed="-e/APPFILE/d"
+elif [ $no_flash -eq 0 ]; then
+    if [ -n "$imgfile" -a -e "$imgfile" ]; then
+	appfile_sed="-es,APPFILE,$imgfile,"
+    else
+	echo "ERR: rootfs image not specified or missing: $imgfile" >&2
+	exit 1
+    fi
+else
+    touch APPFILE
+fi
+sed -e"s,VERFILE,${MACHINE}_bootblob_ver.txt," -e"s,BPFDTB_FILE,$BPFDTB_FILE," $appfile_sed "$flash_in" > flash.xml
 
 BINSARGS="mb2_bootloader nvtboot_recovery_t194.bin; \
 mts_preboot preboot_c10_prod_cr.bin; \
@@ -256,7 +272,7 @@ elif [ -n "$keyfile" ]; then
     SOSARGS="--applet mb1_t194_prod.bin "
     BCTARGS="$bctargs"
     . "$here/odmsign.func"
-    odmsign_ext || exit 1
+    (odmsign_ext) || exit 1
     if [ $no_flash -ne 0 ]; then
 	if [ -f flashcmd.txt ]; then
 	    chmod +x flashcmd.txt
@@ -264,6 +280,7 @@ elif [ -n "$keyfile" ]; then
 	else
 	    echo "WARN: signing completed successfully, but flashcmd.txt missing" >&2
 	fi
+	rm APPFILE
     fi
     exit 0
 else

--- a/recipes-bsp/u-boot/u-boot-bup-payload.bb
+++ b/recipes-bsp/u-boot/u-boot-bup-payload.bb
@@ -31,6 +31,15 @@ do_deploy() {
 		    oe_make_bup_payload ${DEPLOY_DIR_IMAGE}/u-boot-${type}.${UBOOT_SUFFIX}
                     install -d ${DEPLOYDIR}
                     install -m 644 ${WORKDIR}/bup-payload/bl_update_payload ${DEPLOYDIR}/u-boot-${type}.${UBOOT_SUFFIX}.bup-payload
+		    for f in ${WORKDIR}/bup-payload/*_only_payload; do
+			[ -e $f ] || continue
+			sfx=$(basename $f _payload)
+			install -m 0644 $f ${DEPLOYDIR}/u-boot-${type}.${UBOOT_SUFFIX}.$sfx.bup-payload
+			ln -sf u-boot-${type}.${UBOOT_SUFFIX}.$sfx.bup-payload ${DEPLOYDIR}/${UBOOT_IMAGE}-${type}.$sfx.bup-payload
+			ln -sf u-boot-${type}.${UBOOT_SUFFIX}.$sfx.bup-payload ${DEPLOYDIR}/${UBOOT_IMAGE}.$sfx.bup-payload
+			ln -sf u-boot-${type}.${UBOOT_SUFFIX}.$sfx.bup-payload ${DEPLOYDIR}/${UBOOT_BINARY}-${type}.$sfx.bup-payload
+			ln -sf u-boot-${type}.${UBOOT_SUFFIX}.$sfx.bup-payload ${DEPLOYDIR}/${UBOOT_BINARY}.$sfx.bup-payload
+		    done
                     cd ${DEPLOYDIR}
                     ln -sf u-boot-${type}.${UBOOT_SUFFIX}.bup-payload ${UBOOT_IMAGE}-${type}.bup-payload
                     ln -sf u-boot-${type}.${UBOOT_SUFFIX}.bup-payload ${UBOOT_IMAGE}.bup-payload
@@ -47,6 +56,12 @@ do_deploy() {
         rm -f ${DEPLOYDIR}/${UBOOT_BINARY}.bup-payload
         install -m 644 ${WORKDIR}/bup-payload/bl_update_payload ${DEPLOYDIR}/${UBOOT_IMAGE}.bup-payload
         ln -sf ${UBOOT_IMAGE}.bup-payload ${DEPLOYDIR}/${UBOOT_BINARY}.bup-payload
+	for f in ${WORKDIR}/bup-payload/*_only_payload; do
+	    [ -e $f ] || continue
+	    sfx=$(basename $f _payload)
+	    install -m 0644 $f ${DEPLOYDIR}/${UBOOT_IMAGE}.$sfx.bup-payload
+	    ln -sf ${UBOOT_IMAGE}.$sfx.bup-payload ${DEPLOYDIR}/${UBOOT_BINARY}.$sfx.bup-payload
+	done
     fi
 }
 do_deploy[depends] += "virtual/bootloader:do_deploy virtual/kernel:do_deploy ${SOC_FAMILY}-flashtools-native:do_populate_sysroot"

--- a/recipes-bsp/u-boot/u-boot-bup-payload.bb
+++ b/recipes-bsp/u-boot/u-boot-bup-payload.bb
@@ -65,7 +65,7 @@ do_deploy() {
     fi
 }
 do_deploy[depends] += "virtual/bootloader:do_deploy virtual/kernel:do_deploy ${SOC_FAMILY}-flashtools-native:do_populate_sysroot"
-do_deploy[depends] += "tegra-redundant-boot-base:do_populate_sysroot tegra-bootfiles:do_populate_sysroot nv-tegra-release:do_populate_sysroot"
+do_deploy[depends] += "tegra-redundant-boot-base:do_populate_sysroot tegra-bootfiles:do_populate_sysroott"
 do_deploy[depends] += "coreutils-native:do_populate_sysroot cboot:do_deploy virtual/secure-os:do_deploy"
 addtask deploy before do_build
 

--- a/recipes-kernel/kernel-bup-payload/kernel-bup-payload.bb
+++ b/recipes-kernel/kernel-bup-payload/kernel-bup-payload.bb
@@ -34,7 +34,7 @@ do_deploy() {
     fi
 }
 do_deploy[depends] += "virtual/kernel:do_deploy ${SOC_FAMILY}-flashtools-native:do_populate_sysroot dtc-native:do_populate_sysroot"
-do_deploy[depends] += "tegra-redundant-boot-base:do_populate_sysroot tegra-bootfiles:do_populate_sysroot nv-tegra-release:do_populate_sysroot"
+do_deploy[depends] += "tegra-redundant-boot-base:do_populate_sysroot tegra-bootfiles:do_populate_sysroot"
 do_deploy[depends] += "coreutils-native:do_populate_sysroot cboot:do_deploy virtual/secure-os:do_deploy"
 addtask deploy before do_build
 

--- a/recipes-kernel/kernel-bup-payload/kernel-bup-payload.bb
+++ b/recipes-kernel/kernel-bup-payload/kernel-bup-payload.bb
@@ -25,6 +25,11 @@ do_deploy() {
 	    oe_make_bup_payload ${DEPLOY_DIR_IMAGE}/${initramfs_symlink_name}.cboot
 	    install -d ${DEPLOYDIR}
 	    install -m 0644 ${WORKDIR}/bup-payload/bl_update_payload ${DEPLOYDIR}/${initramfs_symlink_name}.bup-payload
+	    for f in ${WORKDIR}/bup-payload/*_only_payload; do
+		[ -e $f ] || continue
+		sfx=$(basename $f _payload)
+		install -m 0644 $f ${DEPLOYDIR}/${initramfs_symlink_name}.$sfx.bup-payload
+	    done
 	done
     fi
 }


### PR DESCRIPTION
This patch series updates how tegraflash packages are created to include the tools and files needed to create BUP payloads from the unpacked package, including a `generate_bup_payload.sh` script to automate the payload creation.

There are related changes to the flash helper scripts.

Other changes include:
* a fix for the tegra194 helper script to better handle a null BOARDEV setting for BUP payload generation
* Extending the recipes that generate BUP payloads to deploy the kernel-only, bl-only, and any other (platform-specific) partial update payloads
* Some minor dependency cleanup

Fixes #302 