### PR TITLE
add support for rootfstype kernel param when mounting rootfs from initrd

### DIFF
--- a/recipes-core/initrdscripts/tegra-minimal-init/init-boot.sh
+++ b/recipes-core/initrdscripts/tegra-minimal-init/init-boot.sh
@@ -7,6 +7,7 @@ mount -t sysfs sysfs /sys
 rootdev=""
 opt="rw"
 wait=""
+fstype="auto"
 
 [ ! -f /etc/platform-preboot ] || . /etc/platform-preboot
 
@@ -16,6 +17,7 @@ if [ -z "$rootdev" ]; then
 	    root=*) rootdev="${bootarg##root=}" ;;
 	    ro) opt="ro" ;;
 	    rootwait) wait="yes" ;;
+        rootfstype=*) fstype="${bootarg##rootfstype=}" ;;
 	esac
     done
 fi
@@ -30,7 +32,7 @@ if [ -n "$wait" -a ! -b "${rootdev}" ]; then
     done
 fi
 echo "Mounting ${rootdev}..."
-mount -t ext4 -o "$opt" "${rootdev}" /mnt || exec sh
+mount -t "${fstype}" -o "${opt}" "${rootdev}" /mnt || exec sh
 echo "Switching to rootfs on ${rootdev}..."
 mount --move /sys  /mnt/sys
 mount --move /proc /mnt/proc


### PR DESCRIPTION
When we mount the root device we used ext4 hardcoded. In this commit I changed the root file system type to inherit from the `rootfstype` kernel argument. If this fails we try to mount using the `auto` type.