### PR TITLE
linux-tegra: Use features from linux-yocto.inc

### DIFF
--- a/recipes-kernel/linux/linux-tegra_4.9.bb
+++ b/recipes-kernel/linux/linux-tegra_4.9.bb
@@ -4,33 +4,22 @@ DESCRIPTION = "Linux kernel from sources provided by Nvidia for Tegra processors
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
 
-inherit kernel
+require recipes-kernel/linux/linux-yocto.inc
 
-PV .= "+git${SRCPV}"
+LINUX_VERSION ?= "4.9.140"
+PV = "${LINUX_VERSION}+git${SRCPV}"
 FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}-${@bb.parse.BBHandler.vars_from_file(d.getVar('FILE', False),d)[1]}:"
 EXTRA_OEMAKE += 'LIBGCC=""'
 
-L4T_VERSION = "l4t-r32.3.1"
-SCMVERSION ??= "y"
-export LOCALVERSION = ""
+LINUX_VERSION_EXTENSION ?= "-l4t-r32.3.1"
 
-SRCBRANCH = "patches-${L4T_VERSION}"
+KBRANCH = "patches${LINUX_VERSION_EXTENSION}"
 SRCREV = "47e7e1cb0b492487faa6258a4f3efe91676568b7"
 KERNEL_REPO = "github.com/madisongh/linux-tegra-4.9"
-SRC_URI = "git://${KERNEL_REPO};branch=${SRCBRANCH} \
+SRC_URI = "git://${KERNEL_REPO};branch=${KBRANCH} \
 	   file://defconfig \
 "
 S = "${WORKDIR}/git"
-
-do_configure_prepend() {
-    localversion="-${L4T_VERSION}"
-    if [ "${SCMVERSION}" = "y" ]; then
-	head=`git --git-dir=${S}/.git rev-parse --verify --short HEAD 2> /dev/null`
-        [ -z "$head" ] || localversion="${localversion}+g${head}"
-    fi
-    sed -e"s,^CONFIG_LOCALVERSION=.*$,CONFIG_LOCALVERSION=\"${localversion}\"," \
-	< ${WORKDIR}/defconfig > ${B}/.config
-}
 
 COMPATIBLE_MACHINE = "(tegra)"
 


### PR DESCRIPTION
Including linux-yocto.inc simplifies the recipe file. This also allows
the kernel recipe (and bbappends) to take advantage of KERNEL_FEATURES.
Using KERNEL_FEATURES allows distro layers to modify the kernel config
by using kernel config fragments and .scc files. Most importantly, this
commit keeps from overwriting the .config file in ${B} which makes it
difficult to modify the kernel config from a distro layer.

I am creating a pull request for the thud-l4t-r32.3.1 branch since that is the branch I have tested it on, but I am hoping this can be ported forward to other branches like master.