### PR TITLE
cboot: add version number to downloaded source tarball

### DIFF
--- a/recipes-bsp/cboot/cboot_32.4.2.bb
+++ b/recipes-bsp/cboot/cboot_32.4.2.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = " \
     file://bootloader/partner/common/lib/external/lz4/lz4.c;endline=33;md5=374dbaf7e07d3845e06cbab8589578e9 \
     file://bootloader/partner/common/lib/external/mincrypt/sha.c;endline=34;md5=4a0fce84ffc9e3901a9fb2e2a290e7b8 \
     file://bootloader/partner/common/lib/external/zlib/zlib.h;beginline=6;endline=23;md5=5377232268e952e9ef63bc555f7aa6c0 \
-    file://bootloader/partner/common/drivers/display/tegrabl_display.c;endline=9;md5=c8ca1ecaf97ac64ea801dd20a81d463a \
+    file://LICENSE.cboot.txt;md5=972762a86d83ebd2df0b07be8d084935 \
 "
 
 inherit l4t_bsp
@@ -17,7 +17,7 @@ inherit l4t_bsp
 L4T_BSP_NAME = "${L4T_SRCS_NAME}"
 
 SRC_URI = "\
-    ${L4T_URI_BASE}/cboot_src_t19x.tbz2 \
+    ${L4T_URI_BASE}/cboot_src_t19x.tbz2;downloadfilename=cboot_src_t19x-${PV}.tbz2;subdir=${BP} \
     file://0001-Convert-Python-scripts-to-Python3.patch \
 "
 SRC_URI[sha256sum] = "851a2c3b3dcfc7ed718050d55ce5941b2385e81bdc6d2d4cb6f324606dd5efe2"
@@ -26,4 +26,4 @@ require cboot-l4t.inc
 
 COMPATIBLE_MACHINE = "(tegra194)"
 
-S = "${WORKDIR}"
+S = "${WORKDIR}/${BP}"


### PR DESCRIPTION
Fix the SRC_URI setting to rename the downloaded tarball to
include the version number, so we don't get conflicts when
building multiple versions using a shared downloads area.

While here, also add a 'subdir' parameter so the sources
are downloaded into an appropriately named subdirectory
under ${WORKDIR}, and set S accordingly.

And now that NVIDIA includes a LICENSE file in the
package, use that in LIC_FILES_CHKSUM instead one of
the source files.

Signed-off-by: Matt Madison <matt@madison.systems>