### PR TITLE
tegra-common: add machine extra rdepends for egl-wayland when required

### DIFF
--- a/recipes-graphics/libglvnd/libglvnd_1.2.0.bb
+++ b/recipes-graphics/libglvnd/libglvnd_1.2.0.bb
@@ -51,3 +51,5 @@ RCONFLICTS_${PN} = "libegl libgl ligbles1 libgles2"
 RCONFLICTS_${PN}-dev += "libegl-dev libgl-dev libgles1-dev libgles2-dev"
 RREPLACES_${PN} = "libegl libgl libgles1 ligbles2"
 RREPLACESS_${PN}-dev += "libegl-dev libgl-dev libgles1-dev libgles2-dev"
+
+RRECOMMENDS_${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'egl-wayland', '', d)}"


### PR DESCRIPTION
Currently, egl-wayland is included at runtime only when the weston
compositor is used, or when egl-wayland is explicitly included in
the image. But really, the compositor doesn't need to use it -- the
compositor renders with egldevice platform or some other mechanism,
and it's the clients who need the egl-wayland platform if they want
to create a wayland egl surface. To be fair, weston does actually use
the library, but only for an optional interface.

It's not valid to assume that weston will always be the compositor,
and regardless of the compositor, clients may still need this backend.

This change puts egl-wayland in the MACHINE_EXTRA_RDEPENDS inside of
tegra-common.inc so all tegra machines will have egl-wayland if the
distro uses wayland, regardless of the compositor being used.