### PR TITLE
opencv: fix configuration with nvidia optical flow

### DIFF
--- a/external/openembedded-layer/recipes-support/opencv/opencv_4.3.0.bbappend
+++ b/external/openembedded-layer/recipes-support/opencv/opencv_4.3.0.bbappend
@@ -4,6 +4,12 @@ EXTRA_OECMAKE_append_tegra210 = ' -DWITH_CUDA=ON -DCUDA_ARCH_BIN="5.3" -DCUDA_AR
 EXTRA_OECMAKE_append_tegra186 = ' -DWITH_CUDA=ON -DCUDA_ARCH_BIN="6.2" -DCUDA_ARCH_PTX=""'
 EXTRA_OECMAKE_append_tegra194 = ' -DWITH_CUDA=ON -DCUDA_ARCH_BIN="7.2" -DCUDA_ARCH_PTX=""'
 
-EXTRA_OECMAKE_append_tegra = " -DBUILD_opencv_cudaoptflow=OFF"
-
 EXTRA_OECMAKE_append = " -DOPENCV_GENERATE_PKGCONFIG=ON"
+
+OPTICALFLOW_MD5 = "ca5acedee6cb45d0ec610a6732de5c15"
+OPTICALFLOW_HASH = "79c6cee80a2df9a196f20afd6b598a9810964c32"
+
+SRC_URI += "https://github.com/NVIDIA/NVIDIAOpticalFlowSDK/archive/${OPTICALFLOW_HASH}.zip;name=opticalflow;unpack=false;subdir=${OPENCV_DLDIR}/nvidia_optical_flow;downloadfilename=${OPTICALFLOW_MD5}-${OPTICALFLOW_HASH}.zip"
+
+SRC_URI[opticalflow.md5sum] = "${OPTICALFLOW_MD5}"
+SRC_URI[opticalflow.sha256sum] = "c6ce0a9bc628b354b0b59a9677edc45c9ee2f640f3abb7353a94fe28b2689ed4"


### PR DESCRIPTION
When cuda is enabled, the configuration script attempts to fetch the
headers for nvidia optical flow:

| -- NVIDIA_OPTICAL_FLOW: Download: 79c6cee80a2df9a196f20afd6b598a9810964c32.zip
| CMake Error at /path/to/tmp/work/armv8a_tegra194-oe-linux/opencv/4.3.0-r0/git/cmake/OpenCVDownload.cmake:161 (message):
|   Not going to download 79c6cee80a2df9a196f20afd6b598a9810964c32.zip
| Call Stack (most recent call first):
|   /path/to/tmp/work/armv8a_tegra194-oe-linux/opencv/4.3.0-r0/contrib/modules/cudaoptflow/CMakeLists.txt:14 (ocv_download)

This change pre-fetches the archive into the opencv download cache.