### PR TITLE
Add CuDNN support to OpenCV builds

### DIFF
--- a/external/openembedded-layer/recipes-support/opencv/opencv/0001-Fix-search-paths-in-FindCUDNN.cmake.patch
+++ b/external/openembedded-layer/recipes-support/opencv/opencv/0001-Fix-search-paths-in-FindCUDNN.cmake.patch
@@ -1,0 +1,45 @@
+From 4fb8438d09685b62fe9542bc08dc96ebaa820dc9 Mon Sep 17 00:00:00 2001
+From: Matt Madison <matt@madison.systems>
+Date: Sat, 6 Jun 2020 06:33:34 -0700
+Subject: [PATCH] Fix search paths in FindCUDNN.cmake
+
+- CuDNN libraries are not located in CUDA toolkit
+- CuDNN version info is in cudnn_version.h, not cudnn.h,
+  starting with version 8
+---
+ cmake/FindCUDNN.cmake | 15 +++++++++++----
+ 1 file changed, 11 insertions(+), 4 deletions(-)
+
+diff --git a/cmake/FindCUDNN.cmake b/cmake/FindCUDNN.cmake
+index e115f80347..9efee59385 100644
+--- a/cmake/FindCUDNN.cmake
++++ b/cmake/FindCUDNN.cmake
+@@ -41,9 +41,12 @@ The following cache variables will be set if cuDNN was found. They may also be s
+ 
+ # find the library
+ if(CUDA_FOUND)
+-  find_cuda_helper_libs(cudnn)
+-  set(CUDNN_LIBRARY ${CUDA_cudnn_LIBRARY} CACHE FILEPATH "location of the cuDNN library")
+-  unset(CUDA_cudnn_LIBRARY CACHE)
++  find_library(CUDNN_LIBRARY NAMES cudnn)
++  if(NOT CUDNN_LIBRARY)
++    find_cuda_helper_libs(cudnn)
++    set(CUDNN_LIBRARY ${CUDA_cudnn_LIBRARY} CACHE FILEPATH "location of the cuDNN library")
++    unset(CUDA_cudnn_LIBRARY CACHE)
++  endif()
+ endif()
+ 
+ # find the include
+@@ -65,7 +68,11 @@ endif()
+ 
+ # extract version from the include
+ if(CUDNN_INCLUDE_DIR)
+-  file(READ "${CUDNN_INCLUDE_DIR}/cudnn.h" CUDNN_H_CONTENTS)
++  if(EXISTS "${CUDNN_INCLUDE_DIR}/cudnn_version.h")
++    file(READ "${CUDNN_INCLUDE_DIR}/cudnn_version.h" CUDNN_H_CONTENTS)
++  else()
++    file(READ "${CUDNN_INCLUDE_DIR}/cudnn.h" CUDNN_H_CONTENTS)
++  endif()
+ 
+   string(REGEX MATCH "define CUDNN_MAJOR ([0-9]+)" _ "${CUDNN_H_CONTENTS}")
+   set(CUDNN_MAJOR_VERSION ${CMAKE_MATCH_1} CACHE INTERNAL "")

--- a/external/openembedded-layer/recipes-support/opencv/opencv_4.3.0.bbappend
+++ b/external/openembedded-layer/recipes-support/opencv/opencv_4.3.0.bbappend
@@ -1,3 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+
 inherit cuda
 
 EXTRA_OECMAKE_append_tegra210 = ' -DWITH_CUDA=ON -DCUDA_ARCH_BIN="5.3" -DCUDA_ARCH_PTX=""'
@@ -13,3 +15,9 @@ SRC_URI += "https://github.com/NVIDIA/NVIDIAOpticalFlowSDK/archive/${OPTICALFLOW
 
 SRC_URI[opticalflow.md5sum] = "${OPTICALFLOW_MD5}"
 SRC_URI[opticalflow.sha256sum] = "c6ce0a9bc628b354b0b59a9677edc45c9ee2f640f3abb7353a94fe28b2689ed4"
+
+# No stable URI is available for NVIDIAOpticalFlowSDK
+INSANE_SKIP_append = " src-uri-bad"
+
+DEPENDS_append_cuda = "${@' cudnn' if 'dnn' in d.getVar('PACKAGECONFIG') else ''}"
+SRC_URI += "file://0001-Fix-search-paths-in-FindCUDNN.cmake.patch"

--- a/recipes-devtools/cudnn/cudnn_8.0.0.145-1.bb
+++ b/recipes-devtools/cudnn/cudnn_8.0.0.145-1.bb
@@ -40,12 +40,17 @@ do_compile() {
 do_install() {
     install -d ${D}${includedir} ${D}${libdir} ${D}${datadir} ${D}${prefix}/src
     install -m 0644 ${S}/usr/include/aarch64-linux-gnu/*.h ${D}${includedir}
+    for f in ${D}${includedir}/*_v${MAJVER}.h; do
+	incname=$(basename $f)
+	ln -s ${incname} ${D}${includedir}/$(basename ${incname} _v${MAJVER}.h).h
+    done
     for f in ${S}/usr/lib/aarch64-linux-gnu/*.so.${BASEVER}; do
 	libname=$(basename $f .so.${BASEVER})
 	install -m 0644 ${S}/usr/lib/aarch64-linux-gnu/${libname}.so.${BASEVER} ${D}${libdir}/
 	install -m 0644 ${S}/usr/lib/aarch64-linux-gnu/${libname}_static_v${MAJVER}.a ${D}${libdir}/
 	ln -s ${libname}.so.${BASEVER} ${D}${libdir}/${libname}.so.${MAJVER}
 	ln -s ${libname}.so.${BASEVER} ${D}${libdir}/${libname}.so
+	ln -s ${libname}_static_v${MAJVER}.a ${D}${libdir}/${libname}_static.a
     done
     cp --preserve=mode,timestamps --recursive ${S}/usr/share/* ${D}${datadir}/
     rm -rf ${D}${datadir}/lintian


### PR DESCRIPTION
This required fixing cudnn installs to include the un-version-suffixed header files and static libraries, as well as a patch to OpenCV so it looks for libcudnn in the right place and uses the right header file to extract version information (due to changes in CuDNN 8.0).
