### PR TITLE
machine: Add a default value for IMAGE_FSTYPES

### DIFF
--- a/conf/machine/include/tegra194.inc
+++ b/conf/machine/include/tegra194.inc
@@ -12,7 +12,7 @@ MACHINE_ESSENTIAL_EXTRA_RDEPENDS = "tegra-firmware kernel-devicetree kernel-imag
 MACHINE_EXTRA_RDEPENDS = "tegra-nvpmodel tegra-nvphs tegra-nvs-service tegra-nvstartup tegra-configs-udev kernel-module-nvgpu"
 
 INITRD_IMAGE ?=	"tegra-minimal-initramfs"
-IMAGE_CLASSES_append = " image_types_cboot"
+IMAGE_CLASSES_append = " image_types_tegra"
 INITRD_FSTYPES ?= "cpio.gz.cboot cpio.gz.cboot.bup-payload"
 IMAGE_UBOOT ?= ""
 

--- a/conf/machine/jetson-xavier.conf
+++ b/conf/machine/jetson-xavier.conf
@@ -4,6 +4,8 @@
 
 require conf/machine/include/tegra194.inc
 
+IMAGE_FSTYPES ?= "tegraflash"
+
 KERNEL_DEVICETREE ?= "_ddot_/_ddot_/_ddot_/_ddot_/nvidia/platform/t19x/galen/kernel-dts/tegra194-p2888-0001-p2822-0000.dtb"
 KERNEL_ARGS ?= "console=ttyTCU0,115200 console=tty0 OS=l4t fbcon=map:0"
 


### PR DESCRIPTION
Yocto documentation recommends setting this variable in your machine
configuration file. This has the added benefit of making it simpler to
start using this layer and is needed when building the same image using
two different BSP layers with custom IMAGE_CLASSES.