### PR TITLE
linux-tegra: add patch for devtool compatibility

### DIFF
--- a/recipes-kernel/linux/linux-tegra-4.9/0001-Change-kernel-version-lineno-in-Makefile-for-devtool-compatibility.patch
+++ b/recipes-kernel/linux/linux-tegra-4.9/0001-Change-kernel-version-lineno-in-Makefile-for-devtool-compatibility.patch
@@ -1,0 +1,45 @@
+From 0e2e437441595bfa38d971dd0b4143c058fa6f3d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Mustafa=20=C3=96z=C3=A7elik=C3=B6rs?=
+ <mozcelikors@gmail.com>
+Date: Thu, 11 Jun 2020 12:24:14 +0300
+Subject: [PATCH] Change kernel version line number in Makefile for devtool compatibility
+ When "devtool modify linux-tegra" is invoked, get_staging_kver function in poky/scripts/lib/devtool/standard.py
+ results in a parse error. Devtool parses first few lines for the kernel version with its current implementation.
+ Therefore to make linux-tegra Makefile compatible with devtool, first few lines should contain kernel version information.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Mustafa Özçelikörs <mozcelikors@gmail.com>
+---
+ Makefile | 13 +++++++------
+ 1 file changed, 7 insertions(+), 6 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 47a8af779b67..32da422807a1 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,3 +1,10 @@
++
++VERSION = 4
++PATCHLEVEL = 9
++SUBLEVEL = 140
++EXTRAVERSION =
++NAME = Roaring Lionus
++
+ ifeq ($(KERNEL_OVERLAYS),)
+ KERNEL_OVERLAYS :=
+ KERNEL_OVERLAYS += $(CURDIR)/nvidia
+@@ -15,12 +22,6 @@ define set_srctree_overlay
+ endef
+ $(foreach overlay,$(KERNEL_OVERLAYS),$(eval $(value set_srctree_overlay)))
+ 
+-VERSION = 4
+-PATCHLEVEL = 9
+-SUBLEVEL = 140
+-EXTRAVERSION =
+-NAME = Roaring Lionus
+-
+ # *DOCUMENTATION*
+ # To see a list of typical targets execute "make help"
+ # More info can be located in ./README

--- a/recipes-kernel/linux/linux-tegra_4.9.bb
+++ b/recipes-kernel/linux/linux-tegra_4.9.bb
@@ -21,6 +21,7 @@ SRC_REPO = "github.com/madisongh/linux-tegra-4.9"
 KERNEL_REPO = "${SRC_REPO}"
 SRC_URI = "git://${KERNEL_REPO};name=machine;branch=${KBRANCH} \
 	   ${@'file://localversion_auto.cfg' if d.getVar('SCMVERSION') == 'y' else ''} \
+           file://0001-Change-kernel-version-lineno-in-Makefile-for-devtool-compatibility.patch \
 "
 
 KBUILD_DEFCONFIG = "tegra_defconfig"


### PR DESCRIPTION
When "devtool modify linux-tegra" is invoked, get_staging_kver function in poky/scripts/lib/devtool/standard.py results in a parse error. Devtool parses first few lines for the kernel version with its current implementation. Therefore to make linux-tegra Makefile compatible with devtool, first few lines should contain kernel version information.
This commit introduces a patch that makes linux-tegra usable with general Yocto devtool workflow.
Patch could be cherry-picked to other branches that suffer the same problem.

Signed-off-by: Mustafa Özçelikörs <mozcelikors@gmail.com>