### PR TITLE
remove kernel-devicetree from MACHINE_ESSENTIAL_EXTRA_RDEPENDS

### DIFF
--- a/conf/machine/include/tegra186.inc
+++ b/conf/machine/include/tegra186.inc
@@ -9,7 +9,7 @@ KERNEL_IMAGETYPE = "Image"
 KERNEL_ARGS ?= "console=ttyS0,115200 console=tty0 fbcon=map:0 isolcpus=1-2"
 
 MACHINE_FEATURES = "alsa usbhost pci rtc cuda"
-MACHINE_ESSENTIAL_EXTRA_RDEPENDS = "tegra-firmware ${@'' if d.getVar('PREFERRED_PROVIDER_virtual/bootloader').startswith('cboot') else 'kernel-devicetree kernel-image u-boot'}"
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS = "tegra-firmware ${@'' if d.getVar('PREFERRED_PROVIDER_virtual/bootloader').startswith('cboot') else 'kernel-image u-boot'}"
 MACHINE_EXTRA_RDEPENDS = "tegra-nvpmodel tegra-nvphs tegra-nvs-service tegra-nvstartup tegra-configs-udev"
 MACHINE_EXTRA_RRECOMMENDS = "kernel-module-nvgpu kernel-module-tegra-udrm"
 


### PR DESCRIPTION
In the jetson, cboot is used to load device tree from its dedicated partition.

Thus, it is not needed to install it into rootfs

Signed-off-by: Shlomi Vaknin <shlomi.39sd@gmail.com>

I guess it is needed in other platforms as well, but I don't familliar with them.
By the way, we don't really need the whole u-boot package. What I did in another commit is to 
create a bbappend to u-boot and create a package that includes only the exlinux and initrd. What is your opinion?