### PR TITLE
Add libvisionworks 1.6 in FILES

### DIFF
--- a/recipes-devtools/visionworks/libvisionworks_1.6.0.501.bb
+++ b/recipes-devtools/visionworks/libvisionworks_1.6.0.501.bb
@@ -35,7 +35,6 @@ INHIBIT_PACKAGE_STRIP = "1"
 INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
 INHIBIT_SYSROOT_STRIP = "1"
 
-FILES_${PN} = "${libdir}/libvisionworks.so*"
-FILES_${PN}-dev = "${includedir} ${libdir}/pkgconfig ${datadir}/visionworks"
+FILES_${PN}-dev = "${datadir}/visionworks"
 RDEPENDS_${PN} = "libstdc++"
 PACKAGE_ARCH = "${SOC_FAMILY_PKGARCH}"

--- a/recipes-devtools/visionworks/libvisionworks_1.6.0.501.bb
+++ b/recipes-devtools/visionworks/libvisionworks_1.6.0.501.bb
@@ -27,7 +27,7 @@ do_install() {
     install -d ${D}${prefix} ${D}${libdir} ${D}${datadir} ${D}${libdir}/pkgconfig
     cp -R --preserve=mode,timestamps ${B}/usr/include ${D}${prefix}/
     cp -R --preserve=mode,timestamps ${B}/usr/lib/pkgconfig/* ${D}${libdir}/pkgconfig
-    cp --preserve=mode,timestamps ${B}/usr/lib/libvisionworks.so* ${D}${libdir}/
+    cp --preserve=mode,timestamps,links --no-dereference ${B}/usr/lib/libvisionworks.so* ${D}${libdir}/
     cp -R --preserve=mode,timestamps ${B}/usr/share/visionworks ${D}${datadir}/
 }
 

--- a/recipes-devtools/visionworks/libvisionworks_1.6.0.501.bb
+++ b/recipes-devtools/visionworks/libvisionworks_1.6.0.501.bb
@@ -27,7 +27,7 @@ do_install() {
     install -d ${D}${prefix} ${D}${libdir} ${D}${datadir} ${D}${libdir}/pkgconfig
     cp -R --preserve=mode,timestamps ${B}/usr/include ${D}${prefix}/
     cp -R --preserve=mode,timestamps ${B}/usr/lib/pkgconfig/* ${D}${libdir}/pkgconfig
-    cp --preserve=mode,timestamps ${B}/usr/lib/libvisionworks.so ${D}${libdir}/
+    cp --preserve=mode,timestamps ${B}/usr/lib/libvisionworks.so* ${D}${libdir}/
     cp -R --preserve=mode,timestamps ${B}/usr/share/visionworks ${D}${datadir}/
 }
 
@@ -35,7 +35,7 @@ INHIBIT_PACKAGE_STRIP = "1"
 INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
 INHIBIT_SYSROOT_STRIP = "1"
 
-FILES_${PN} = "${libdir}/libvisionworks.so"
+FILES_${PN} = "${libdir}/libvisionworks.so*"
 FILES_${PN}-dev = "${includedir} ${libdir}/pkgconfig ${datadir}/visionworks"
 RDEPENDS_${PN} = "libstdc++"
 PACKAGE_ARCH = "${SOC_FAMILY_PKGARCH}"


### PR DESCRIPTION
The package VisionWorksTargets.cmake set the location to the
libvisionworks library to '/usr/lib/libvisionworks.so.1.6.0' which is
not present in the recipe.

```
/.../recipe-sysroot/usr/share/visionworks/cmake/VisionWorksTargets.cmake:64 (message):
|   The imported target "visionworks" references the file
|
|      "/.../recipe-sysroot/usr/lib/libvisionworks.so.1.6.0"
```

This add the two following files from the package 'libvisionworks_1.6.0.501_arm64.deb'
- libvisionworks.so.1.6 -> libvisionworks.so.1.6.0
- libvisionworks.so.1.6.0

As a matter of fact, the 'libvisionworks.so' redirect to 'libvisionworks.so.1.6', which is not present.