### PR TITLE
Fix visionworks lib

### DIFF
--- a/recipes-devtools/visionworks/libvisionworks_1.6.0.501.bb
+++ b/recipes-devtools/visionworks/libvisionworks_1.6.0.501.bb
@@ -35,7 +35,6 @@ INHIBIT_PACKAGE_STRIP = "1"
 INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
 INHIBIT_SYSROOT_STRIP = "1"
 
-FILES_${PN} = "${libdir}/libvisionworks.so*"
-FILES_${PN}-dev = "${includedir} ${libdir}/pkgconfig ${datadir}/visionworks"
+FILES_${PN}-dev = "${datadir}/visionworks"
 RDEPENDS_${PN} = "libstdc++"
 PACKAGE_ARCH = "${SOC_FAMILY_PKGARCH}"

--- a/recipes-devtools/visionworks/libvisionworks_1.6.0.501.bb
+++ b/recipes-devtools/visionworks/libvisionworks_1.6.0.501.bb
@@ -35,6 +35,6 @@ INHIBIT_PACKAGE_STRIP = "1"
 INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
 INHIBIT_SYSROOT_STRIP = "1"
 
-FILES_${PN}-dev = "${datadir}/visionworks"
+FILES_${PN}-dev = "${includedir} ${libdir}/libvisionworks.so ${libdir}/pkgconfig ${datadir}/visionworks"
 RDEPENDS_${PN} = "libstdc++"
 PACKAGE_ARCH = "${SOC_FAMILY_PKGARCH}"

--- a/recipes-devtools/visionworks/libvisionworks_1.6.0.501.bb
+++ b/recipes-devtools/visionworks/libvisionworks_1.6.0.501.bb
@@ -27,7 +27,7 @@ do_install() {
     install -d ${D}${prefix} ${D}${libdir} ${D}${datadir} ${D}${libdir}/pkgconfig
     cp -R --preserve=mode,timestamps ${B}/usr/include ${D}${prefix}/
     cp -R --preserve=mode,timestamps ${B}/usr/lib/pkgconfig/* ${D}${libdir}/pkgconfig
-    cp --preserve=mode,timestamps ${B}/usr/lib/libvisionworks.so* ${D}${libdir}/
+    cp --preserve=mode,timestamps,links --no-dereference ${B}/usr/lib/libvisionworks.so* ${D}${libdir}/
     cp -R --preserve=mode,timestamps ${B}/usr/share/visionworks ${D}${datadir}/
 }
 

--- a/recipes-devtools/visionworks/libvisionworks_1.6.0.501.bb
+++ b/recipes-devtools/visionworks/libvisionworks_1.6.0.501.bb
@@ -27,7 +27,7 @@ do_install() {
     install -d ${D}${prefix} ${D}${libdir} ${D}${datadir} ${D}${libdir}/pkgconfig
     cp -R --preserve=mode,timestamps ${B}/usr/include ${D}${prefix}/
     cp -R --preserve=mode,timestamps ${B}/usr/lib/pkgconfig/* ${D}${libdir}/pkgconfig
-    cp --preserve=mode,timestamps ${B}/usr/lib/libvisionworks.so ${D}${libdir}/
+    cp --preserve=mode,timestamps ${B}/usr/lib/libvisionworks.so* ${D}${libdir}/
     cp -R --preserve=mode,timestamps ${B}/usr/share/visionworks ${D}${datadir}/
 }
 
@@ -35,7 +35,7 @@ INHIBIT_PACKAGE_STRIP = "1"
 INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
 INHIBIT_SYSROOT_STRIP = "1"
 
-FILES_${PN} = "${libdir}/libvisionworks.so"
+FILES_${PN} = "${libdir}/libvisionworks.so*"
 FILES_${PN}-dev = "${includedir} ${libdir}/pkgconfig ${datadir}/visionworks"
 RDEPENDS_${PN} = "libstdc++"
 PACKAGE_ARCH = "${SOC_FAMILY_PKGARCH}"


### PR DESCRIPTION
We need to reinclude the directories in `FILES_${PN}-dev` as the recipe do not handle it properly
```
ERROR: libvisionworks-1.6.0.501-r0 do_package: QA Issue: libvisionworks: Files/directories were installed but not shipped in any package:
  /usr/include
  /usr/include/NVX
  /usr/include/VX
  /usr/include/NVX/nvx_opencv_interop.hpp
  /usr/include/NVX/nvx_export.h
  /usr/include/NVX/nvx_compatibility.h
  /usr/include/NVX/nvx_version.h
  /usr/include/NVX/nvxcu.h
  /usr/include/NVX/nvx_cuda_interop.h
  /usr/include/NVX/nvx.h
  /usr/include/NVX/nvx_timer.hpp
  /usr/include/NVX/nvx_api_macros.h
  /usr/include/VX/vx_types.h
  /usr/include/VX/vx_api.h
  /usr/include/VX/vx_vendors.h
  /usr/include/VX/vxu.h
  /usr/include/VX/vx.h
  /usr/include/VX/vx_nodes.h
  /usr/include/VX/vx_compatibility.h
  /usr/include/VX/vx_kernels.h
  /usr/lib/libvisionworks.so
  /usr/lib/pkgconfig
  /usr/lib/pkgconfig/visionworks.pc
Please set FILES such that these items are packaged. Alternatively if they are unneeded, avoid installing them or delete them within do_install.
libvisionworks: 23 installed and not shipped files. [installed-vs-shipped]
ERROR: libvisionworks-1.6.0.501-r0 do_package: Fatal QA errors found, failing task.
```