### PR TITLE
contrib: gcc-7, gcc-8: drop obsolete shlibs exclusion

### DIFF
--- a/contrib/recipes-devtools/gcc-7/gcc-cross-canadian.inc
+++ b/contrib/recipes-devtools/gcc-7/gcc-cross-canadian.inc
@@ -63,9 +63,6 @@ do_compile () {
 	(cd ${B}/${TARGET_SYS}/libgcc; oe_runmake enable-execute-stack.c unwind.h md-unwind-support.h sfp-machine.h gthr-default.h)
 }
 
-# Having anything auto depending on gcc-cross-sdk is a really bad idea...
-EXCLUDE_FROM_SHLIBS = "1"
-
 PACKAGES = "${PN}-dbg ${PN} ${PN}-doc"
 
 FILES_${PN} = "\

--- a/contrib/recipes-devtools/gcc-8/gcc-cross-canadian.inc
+++ b/contrib/recipes-devtools/gcc-8/gcc-cross-canadian.inc
@@ -63,9 +63,6 @@ do_compile () {
 	(cd ${B}/${TARGET_SYS}/libgcc; oe_runmake enable-execute-stack.c unwind.h md-unwind-support.h sfp-machine.h gthr-default.h)
 }
 
-# Having anything auto depending on gcc-cross-sdk is a really bad idea...
-EXCLUDE_FROM_SHLIBS = "1"
-
 PACKAGES = "${PN}-dbg ${PN} ${PN}-doc"
 
 FILES_${PN} = "\


### PR DESCRIPTION
from gcc-cross-canadian.inc.  This change was made in
commit 096fa15efbcb704451b2f38ceab36508ef64f07e in OE-Core,
and fixes missing dependencies issues during package QA
for the cross-canadian compiler package.

Signed-off-by: Matt Madison <matt@madison.systems>

Fixes #354