### PR TITLE
cublas build usr/lib/aarch64-linux-gnu/lib*': No such file or directory

### DIFF
--- a/recipes-devtools/cuda/libcublas_10.2.2.89-1.bb
+++ b/recipes-devtools/cuda/libcublas_10.2.2.89-1.bb
@@ -11,9 +11,11 @@ SRC_URI[main.sha256sum] = "d0299b139a163136432dfb2c028769944b6c5636ad9238614860c
 SRC_URI[dev.sha256sum] = "5fa7e3e8fe266fdea7e91778610b7e8d3d85d8950875a4915ce3626c9e564365"
 
 do_compile_append() {
-    mv ${B}/usr/${baselib}/${HOST_ARCH}-linux-gnu/lib* ${B}/usr/${baselib}/
-    rm -rf ${B}/usr/${baselib}/${HOST_ARCH}-linux-gnu/stubs
-    rmdir ${B}/usr/${baselib}/${HOST_ARCH}-linux-gnu
+    if [ -d ${B}/usr/${baselib}/${HOST_ARCH}-linux-gnu/ ]; then
+	    mv ${B}/usr/${baselib}/${HOST_ARCH}-linux-gnu/lib* ${B}/usr/${baselib}/
+	    rm -rf ${B}/usr/${baselib}/${HOST_ARCH}-linux-gnu/stubs
+	    rmdir ${B}/usr/${baselib}/${HOST_ARCH}-linux-gnu
+    fi
     sed -i -e's,^pkgroot=.*,prefix=${prefix},' -e's,{pkgroot},{prefix},g' \
 	-e's! -Wl,-rpath.*!!' ${B}/usr/${baselib}/pkgconfig/cublas-10.pc
     ln -s cublas-10.pc ${B}/usr/${baselib}/pkgconfig/cublas-10.2.pc


### PR DESCRIPTION
I'm not sure how or why this is happening but I noticed today that I get an error `libcublas/10.2.2.89-1-r0/libcublas-10.2.2.89-1/usr/lib/aarch64-linux-gnu/lib*': No such file or directory` during libcublas build.

The error occurs [here](https://github.com/madisongh/meta-tegra/blob/dunfell-l4t-r32.4.2/recipes-devtools/cuda/libcublas_10.2.2.89-1.bb#L14) and after it occurs I can see there is indeed no `libcublas/10.2.2.89-1-r0/usr/lib/aarch64-linux-gnu/` directory but the shared objects are already in `/usr/lib`

```
ls build/tmp/work/*/libcublas/10.2.2.89-1-r0/libcublas-10.2.2.89-1/usr/lib
libcublasLt.so  libcublasLt.so.10  libcublasLt.so.10.2.2.89  libcublasLt_static.a  libcublas.so  libcublas.so.10  libcublas.so.10.2.2.89  libcublas_static.a  libnvblas.so  libnvblas.so.10  libnvblas.so.10.2.2.89  pkgconfig
```
The `libcublas10_10.2.2.89` package definitely has the `aarch64-linux-gnu` directory so there's some sequence I don't understand that appears to be extracting and moving the files and deleting the directory before the relevant do_compile lines.  It's confusing that it's suddenly appeared after working fine previously.

```
:~/.dl$ dpkg-deb -c libcublas10_10.2.2.89-1_arm64.deb
drwxr-xr-x root/root         0 2019-10-29 15:13 ./
drwxr-xr-x root/root         0 2019-10-29 15:13 ./usr/
drwxr-xr-x root/root         0 2019-10-29 15:13 ./usr/share/
drwxr-xr-x root/root         0 2019-10-29 15:13 ./usr/share/doc/
drwxr-xr-x root/root         0 2019-10-29 15:13 ./usr/share/doc/libcublas10/
-rw-r--r-- root/root       147 2019-10-29 15:13 ./usr/share/doc/libcublas10/changelog.Debian.gz
drwxr-xr-x root/root         0 2019-10-29 15:13 ./usr/lib/
drwxr-xr-x root/root         0 2019-10-29 15:13 ./usr/lib/aarch64-linux-gnu/
-rw-r--r-- root/root  80530928 2019-10-29 15:13 ./usr/lib/aarch64-linux-gnu/libcublas.so.10.2.2.89
-rw-r--r-- root/root  33235064 2019-10-29 15:13 ./usr/lib/aarch64-linux-gnu/libcublasLt.so.10.2.2.89
-rw-r--r-- root/root    454216 2019-10-29 15:13 ./usr/lib/aarch64-linux-gnu/libnvblas.so.10.2.2.89
lrwxrwxrwx root/root         0 2019-10-29 15:13 ./usr/lib/aarch64-linux-gnu/libcublasLt.so.10 -> libcublasLt.so.10.2.2.89
lrwxrwxrwx root/root         0 2019-10-29 15:13 ./usr/lib/aarch64-linux-gnu/libcublas.so.10 -> libcublas.so.10.2.2.89
lrwxrwxrwx root/root         0 2019-10-29 15:13 ./usr/lib/aarch64-linux-gnu/libnvblas.so.10 -> libnvblas.so.10.2.2.89
```

The patch here fixes the problem but I'm guessing this isn't the right solution.

Appreciate any suggestions.