### PR TITLE
Directly support data partitions in image_types_tegra and the helper scripts

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/make-sdcard.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/make-sdcard.sh
@@ -130,7 +130,10 @@ write_partitions_to_device() {
 	    continue
 	fi
 	eval "$pline"
-	[ -n "$partfile" ] || continue
+	if [ -z "$partfile" ]; then
+	    i=$(expr $i + 1)
+	    continue
+	fi
 	if [ -e "signed/$partfile" ]; then
 	    partfile="signed/$partfile"
 	elif [ ! -e "$partfile" ]; then

--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra186-flash-helper.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra186-flash-helper.sh
@@ -5,8 +5,9 @@ sbk_keyfile=
 no_flash=0
 flash_cmd=
 imgfile=
+dataimg=
 
-ARGS=$(getopt -n $(basename "$0") -l "bup,no-flash" -o "u:v:" -- "$@")
+ARGS=$(getopt -n $(basename "$0") -l "bup,no-flash,datafile:" -o "u:v:" -- "$@")
 if [ $? -ne 0 ]; then
     echo "Error parsing options" >&2
     exit 1
@@ -23,6 +24,10 @@ while true; do
 	--no-flash)
 	    no_flash=1
 	    shift
+	    ;;
+	--datafile)
+	    dataimg="$2"
+	    shift 2
 	    ;;
 	-u)
 	    keyfile="$2"
@@ -158,16 +163,17 @@ cksum=`cksum ${MACHINE}_bootblob_ver.txt | cut -d' ' -f1`
 echo "BYTES:$bytes CRC32:$cksum" >>${MACHINE}_bootblob_ver.txt
 appfile_sed=
 if [ "$bup_build" = "yes" ]; then
-    appfile_sed="-e/APPFILE/d"
+    appfile_sed="-e/APPFILE/d -e/DATAFILE/d"
 elif [ $no_flash -eq 0 ]; then
     if [ -n "$imgfile" -a -e "$imgfile" ]; then
-	appfile_sed="-es,APPFILE,$imgfile,"
+	appfile_sed="-es,APPFILE,$imgfile, -es,DATAFILE,$dataimg,"
     else
 	echo "ERR: rootfs image not specified or missing: $imgfile" >&2
 	exit 1
     fi
 else
     touch APPFILE
+    [ -z "$dataimg" ] || touch DATAFILE
 fi
 sed -e"s,VERFILE,${MACHINE}_bootblob_ver.txt," -e"s,BPFDTB-FILE,$BPFDTB_FILE," $appfile_sed "$flash_in" > flash.xml
 
@@ -218,7 +224,7 @@ elif [ -n "$keyfile" ]; then
 	else
 	    echo "WARN: signing completed successfully, but flashcmd.txt missing" >&2
 	fi
-	rm APPFILE
+	rm -f APPFILE DATAFILE
     fi
     exit 0
 else


### PR DESCRIPTION
Make it easier to populate a data partition during flashing/SDcard creation by:

* Adding DATAFILE and IMAGE_TEGRAFLASH_DATA variables to image_types_tegra.bbclass. IMAGE_TEGRAFLASH_DATA
can be set to point to the location in the build for the data partition filesystem image. If that's set, DATAFILE should be set to the filename for the filesystem image as it will appear in the tegraflash package.
* Adding support for a `--datafile <filename>`  option on the flash helper scripts.

The helper scripts will automatically handle the extra partition when calling on the underlying NVIDIA scripts for image signing/flashing/BUP generation. Between the bbclass and the helper scripts, both eMMC and SDcard cases should be handled properly.

Use `<filename> DATAFILE </filename>` in your flash layout XML file - i.e., a placeholder similar to `APPFILE` for the rootfs - to have the scripts populate the data partition with the filesystem image you provide.

Also included in this change set is some minor whitespace cleanup in image_types_tegra and a small fix to the make-sdcard script.