### PR TITLE
Backport meta: use bundled initramfs instead of initrd on tegra186/194

### DIFF
--- a/classes/image_types_tegra.bbclass
+++ b/classes/image_types_tegra.bbclass
@@ -11,7 +11,7 @@ TEGRA_SIGNING_ARGS ??= ""
 TEGRA_SIGNING_ENV ??= ""
 
 DTBFILE ?= "${@os.path.basename(d.getVar('KERNEL_DEVICETREE').split()[0])}"
-LNXFILE ?= "${@'${IMAGE_UBOOT}-${MACHINE}.bin' if '${IMAGE_UBOOT}' != '' else '${INITRD_IMAGE}-${MACHINE}.cboot'}"
+LNXFILE ?= "${@'${IMAGE_UBOOT}-${MACHINE}.bin' if '${IMAGE_UBOOT}' != '' else '${KERNEL_IMAGETYPE}-initramfs-${MACHINE}.cboot'}"
 LNXSIZE ?= "67108864"
 
 IMAGE_TEGRAFLASH_FS_TYPE ??= "ext4"
@@ -540,7 +540,7 @@ do_image_tegraflash[depends] += "zip-native:do_populate_sysroot dtc-native:do_po
                                  virtual/kernel:do_deploy ${TEGRAFLASHDEPS} \
                                  ${@'${INITRD_IMAGE}:do_image_complete' if d.getVar('INITRD_IMAGE') != '' else  ''} \
                                  ${@'${IMAGE_UBOOT}:do_deploy ${IMAGE_UBOOT}:do_populate_lic' if d.getVar('IMAGE_UBOOT') != '' else  ''} \
-                                 ${@'cboot:do_deploy' if d.getVar('IMAGE_UBOOT') != '' and d.getVar('SOC_FAMILY') == 'tegra186' else  ''}"
+                                 ${@'cboot:do_deploy' if d.getVar('IMAGE_UBOOT') != '' and d.getVar('SOC_FAMILY') != 'tegra210' else  ''}"
 IMAGE_TYPEDEP_tegraflash += "${IMAGE_TEGRAFLASH_FS_TYPE}"
 
 oe_make_bup_payload() {

--- a/conf/machine/include/tegra194.inc
+++ b/conf/machine/include/tegra194.inc
@@ -12,6 +12,8 @@ MACHINE_ESSENTIAL_EXTRA_RDEPENDS = "tegra-firmware kernel-devicetree kernel-imag
 MACHINE_EXTRA_RDEPENDS = "tegra-nvpmodel tegra-nvphs tegra-nvs-service tegra-configs-nvstartup tegra-configs-udev kernel-module-nvgpu kernel-module-nvs"
 
 INITRD_IMAGE ?=	"tegra-minimal-initramfs"
+INITRAMFS_IMAGE ?= "tegra-minimal-initramfs"
+INITRAMFS_IMAGE_BUNDLE ?= "1"
 IMAGE_CLASSES_append = " image_types_cboot"
 INITRD_FSTYPES ?= "cpio.gz.cboot cpio.gz.cboot.bup-payload"
 IMAGE_UBOOT ?= ""

--- a/recipes-core/images/tegra-minimal-initramfs.bb
+++ b/recipes-core/images/tegra-minimal-initramfs.bb
@@ -2,7 +2,6 @@ DESCRIPTION = "Minimal initramfs image for Tegra platforms"
 LICENSE = "MIT"
 
 TEGRA_INITRD_INSTALL ??= ""
-INITRD_FSTYPES ??= "${INITRAMFS_FSTYPES}"
 
 PACKAGE_INSTALL = "\
     tegra-firmware-xusb \
@@ -20,9 +19,16 @@ COMPATIBLE_MACHINE = "(tegra)"
 
 KERNELDEPMODDEPEND = ""
 
-IMAGE_ROOTFS_SIZE = "8192"
+IMAGE_ROOTFS_SIZE = "32768"
 IMAGE_ROOTFS_EXTRA_SPACE = "0"
 
 inherit core-image
 
-IMAGE_FSTYPES = "${INITRD_FSTYPES}"
+IMAGE_FSTYPES = "${INITRAMFS_FSTYPES}"
+
+SSTATE_SKIP_CREATION_task-image-complete = "0"
+SSTATE_SKIP_CREATION_task-image-qa = "0"
+do_image_complete[vardepsexclude] += "rm_work_rootfs"
+IMAGE_POSTPROCESS_COMMAND = ""
+
+inherit nopackages

--- a/recipes-kernel/linux/linux-tegra_4.9.bb
+++ b/recipes-kernel/linux/linux-tegra_4.9.bb
@@ -32,6 +32,34 @@ do_configure_prepend() {
 	< ${WORKDIR}/defconfig > ${B}/.config
 }
 
+bootimg_from_bundled_initramfs() {
+    if [ ! -z "${INITRAMFS_IMAGE}" -a "${INITRAMFS_IMAGE_BUNDLE}" = "1" ]; then
+        rm -f ${WORKDIR}/initrd
+	touch ${WORKDIR}/initrd
+        for imageType in ${KERNEL_IMAGETYPES} ; do
+	    if [ "$imageType" = "fitImage" ] ; then
+	        continue
+	    fi
+	    initramfs_base_name=${imageType}-${INITRAMFS_NAME}
+	    initramfs_symlink_name=${imageType}-${INITRAMFS_LINK_NAME}
+	    ${STAGING_BINDIR_NATIVE}/tegra186-flash/mkbootimg \
+				    --kernel $deployDir/${initramfs_base_name}.bin \
+				    --ramdisk ${WORKDIR}/initrd \
+				    --output $deployDir/${initramfs_base_name}.cboot
+	    chmod 0644 $deployDir/${initramfs_base_name}.cboot
+	    ln -sf ${initramfs_base_name}.cboot $deployDir/${initramfs_symlink_name}.cboot
+	done
+    fi
+}
+
+do_deploy_append_tegra194() {
+    bootimg_from_bundled_initramfs
+}
+
+EXTRADEPLOYDEPS = ""
+EXTRADEPLOYDEPS_tegra194 = "tegra186-flashtools-native:do_populate_sysroot"
+do_deploy[depends] += "${EXTRADEPLOYDEPS}"
+
 COMPATIBLE_MACHINE = "(tegra)"
 COMPATIBLE_MACHINE_tegra124 = "(-)"
 


### PR DESCRIPTION
This is a backport from master branch, tested those changes won't affect TX2/TX2i

Original Commit: af4492634b6e3c0657973cf20418c95a7d8fe0a4
Original comment:

meta: use bundled initramfs instead of initrd on tegra186/194

cboot appears to mangle the initrd at boot time when it
exceeds a couple of MiB in size, but only if it has
been built separately and combined with the kernel using
mkbootimg.  This does not happen when the initrd is
built into the kernel directly, so work around the cboot
issue by switching to bundling the initramfs into the
kernel on the non-u-boot platforms.

Signed-off-by: Daniel Wang <daniel.wangksu@gmail.com>