### PR TITLE
tegra[186|194]-flash-helper: restore ability to specify flash command

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra186-flash-helper.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra186-flash-helper.sh
@@ -7,7 +7,7 @@ flash_cmd=
 imgfile=
 dataimg=
 
-ARGS=$(getopt -n $(basename "$0") -l "bup,no-flash,datafile:" -o "u:v:" -- "$@")
+ARGS=$(getopt -n $(basename "$0") -l "bup,no-flash,datafile:" -o "u:v:c:" -- "$@")
 if [ $? -ne 0 ]; then
     echo "Error parsing options" >&2
     exit 1

--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra194-flash-helper.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra194-flash-helper.sh
@@ -9,7 +9,7 @@ imgfile=
 dataimg=
 blocksize=4096
 
-ARGS=$(getopt -n $(basename "$0") -l "bup,no-flash,sdcard,datafile:" -o "u:v:s:b:B:y" -- "$@")
+ARGS=$(getopt -n $(basename "$0") -l "bup,no-flash,sdcard,datafile:" -o "u:v:s:b:B:yc:" -- "$@")
 if [ $? -ne 0 ]; then
     echo "Error parsing options" >&2
     exit 1


### PR DESCRIPTION
Allows you to flash a single partition, e.g.:

./doflash.sh -c "write CPUBL-CFG cbo.dtb; reboot"

Regression of changes made in #205