### PR TITLE
Backport virtual/dtb for kirkstone-32.7.x

### DIFF
--- a/recipes-kernel/kernel-bup-payload/kernel-bup-payload.bb
+++ b/recipes-kernel/kernel-bup-payload/kernel-bup-payload.bb
@@ -39,7 +39,7 @@ TEGRA_SIGNING_EXTRA_DEPS ??= ""
 do_deploy[depends] += "virtual/kernel:do_deploy ${SOC_FAMILY}-flashtools-native:do_populate_sysroot dtc-native:do_populate_sysroot"
 do_deploy[depends] += "tegra-redundant-boot-rollback:do_populate_sysroot tegra-bootfiles:do_populate_sysroot"
 do_deploy[depends] += "coreutils-native:do_populate_sysroot cboot:do_deploy virtual/secure-os:do_deploy virtual/bootlogo:do_deploy"
-do_deploy[depends] += "${TEGRA_SIGNING_EXTRA_DEPS}"
+do_deploy[depends] += "${TEGRA_SIGNING_EXTRA_DEPS} ${DTB_EXTRA_DEPS}"
 addtask deploy before do_build
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"


### PR DESCRIPTION
Backport of the following PR https://github.com/OE4T/meta-tegra/pull/1088 onto kirkstone-32.7.x branch:

---

image_types_tegra: add support for virtual/dtb provider

This change adds support (adapted from kernel-fitimage handling) for out-of-tree device tree binary generation. It looks for a provider of virtual/dtb, and if this exists, enables the copying of device tree binaries generated by this recipe.

Signed-off-by: Kurt Kiefer [kurt.kiefer@arthrex.com](mailto:kurt.kiefer@arthrex.com)
