### PR TITLE
meta: fix sstate unihash reporting for intermediate image recipes

### DIFF
--- a/recipes-bsp/uefi/tegra-espimage.bb
+++ b/recipes-bsp/uefi/tegra-espimage.bb
@@ -43,7 +43,7 @@ python sstate_report_unihash() {
 
     if report_unihash:
         ss = sstate_state_fromvars(d)
-        if ss['task'] == 'image_complete':
+        if ss['task'] in ['image_complete','image_qa']:
             os.environ['PSEUDO_DISABLED'] = '1'
         report_unihash(os.getcwd(), ss['task'], d)
 }

--- a/recipes-core/images/tegra-initrd-flash-initramfs.bb
+++ b/recipes-core/images/tegra-initrd-flash-initramfs.bb
@@ -49,7 +49,7 @@ python sstate_report_unihash() {
 
     if report_unihash:
         ss = sstate_state_fromvars(d)
-        if ss['task'] == 'image_complete':
+        if ss['task'] in ['image_complete','image_qa']:
             os.environ['PSEUDO_DISABLED'] = '1'
         report_unihash(os.getcwd(), ss['task'], d)
 }

--- a/recipes-core/images/tegra-minimal-initramfs.bb
+++ b/recipes-core/images/tegra-minimal-initramfs.bb
@@ -52,7 +52,7 @@ python sstate_report_unihash() {
 
     if report_unihash:
         ss = sstate_state_fromvars(d)
-        if ss['task'] == 'image_complete':
+        if ss['task'] in ['image_complete','image_qa']:
             os.environ['PSEUDO_DISABLED'] = '1'
         report_unihash(os.getcwd(), ss['task'], d)
 }


### PR DESCRIPTION
by disabling pseudo for reporting the unihash for both the image_complete and the image_qa tasks.

Fixes #1909 