### PR TITLE
perf: add libtraceevent

### DIFF
--- a/recipes-kernel/perf/perf.bbappend
+++ b/recipes-kernel/perf/perf.bbappend
@@ -1,4 +1,0 @@
-PACKAGECONFIG:tegra ?= "tui libunwind"
-# Need to enable -fcommon on C compilations and disable POSIX yacc
-# mode in bison
-EXTRA_OEMAKE:append:tegra = " EXTRA_CFLAGS='-ldw -fcommon' YFLAGS='--file-prefix-map=${WORKDIR}=/usr/src/debug/${PN}/${EXTENDPE}${PV}-${PR}'"


### PR DESCRIPTION
Add libtraceevent to enable tracepoint support.

This fixes the following error when using perf commands:
 perf probe -x /lib/libc.so.6 -a malloc
   Added new events:
     probe_libc:malloc    (on malloc in /usr/lib/libc.so.6)
     probe_libc:malloc    (on malloc in /usr/lib/libc.so.6)
   perf is not linked with libtraceevent, to use the new probe you can use tracefs:
        cd /sys/kernel/tracing/
        echo 1 > events/probe_libc/malloc/enable
        echo 1 > tracing_on
        cat trace_pipe
        Before removing the probe, echo 0 > events/probe_libc/malloc/enable
 perf record -e probe_libc:malloc -a ls
   event syntax error: 'probe_libc:malloc'
                       \___ unsupported tracepoint