### PR TITLE
root of trust signing: tracks PKC and SBK files with file-checksums

### DIFF
--- a/recipes-bsp/uefi/tegra-uefi-capsules_36.4.4.bb
+++ b/recipes-bsp/uefi/tegra-uefi-capsules_36.4.4.bb
@@ -58,6 +58,7 @@ do_compile() {
         bberror "${B}/tegra-kernel.cap wasn't generated"
     fi
 }
+do_compile[file-checksums] += "${TEGRA_SIGNING_FILECHECKSUMS}"
 
 TEGRA_UEFI_CAPSULE_INSTALL_DIR ??= "/opt/nvidia/UpdateCapsule"
 


### PR DESCRIPTION
This implements file tracking for PKC and SBK files in the same way as in fb8aad7c32e991716bfac8d62f20af2ce31453e9 for UEFI files. Additionally, it fails if PKC or SBK don't exist.

Without this, setting:
TEGRA_SIGNING_ARGS = "-u /path/to/signing-key.pem -v /path/to/encryption-key" that points to files that don't exists will succeed silently.