### PR TITLE
gcc-for-nvcc: Pin to using gcc for compiler

### DIFF
--- a/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc-common.inc
+++ b/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc-common.inc
@@ -8,6 +8,8 @@ NATIVEDEPS = ""
 
 CVE_PRODUCT = "gcc"
 
+TOOLCHAIN = "gcc"
+
 inherit autotools gettext texinfo
 
 BPN = "gcc"


### PR DESCRIPTION
OE does have option to use clang as default C/C++ compiler but gcc is not yet buildable with clang so pin the concerning recipes to always use gcc toolchain