### PR TITLE
nvidia-kernel-oot: fix dtb sign issues

### DIFF
--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
@@ -55,6 +55,8 @@ do_sign_dtbs() {
         local dtb="${B}/kernel-devicetree/generic-dts/dtbs/${dtbf}"
         if [ -e "$dtb" ]; then
             tegra_uefi_attach_sign "$dtb"
+            rm "$dtb"
+            mv "$dtb.signed" "$dtb"
         fi
     done
 }


### PR DESCRIPTION
After signing the dtb files with tegra_uefi_attach_sign, it should replace the original dtb files with the signed ones.