### PR TITLE
tegra-helper-scripts: Check for dtc

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra-flash-helper.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra-flash-helper.sh
@@ -169,6 +169,12 @@ here=$(readlink -f $(dirname "$0"))
 flashappname="tegraflash.py"
 custinfo_out="custinfo_out.bin"
 
+# tegraflash.py depends on the dtc command
+if ! command -v dtc >/dev/null 2>&1; then
+    echo "ERR: 'dtc' command not found. Please install the 'device-tree-compiler' package." >&2
+    exit 1
+fi
+
 if [ ! -e ./flashvars ]; then
     echo "ERR: missing flash variables file" >&2
     exit 1


### PR DESCRIPTION
Verify that the `dtc` command is available, and if not, display a user-friendly error message recommending installation of the 'device-tree-compiler' package.

This avoids running in the following error due to missing dtc:

```
FileNotFoundError: [Errno 2] No such file or directory: 'dtc'
```

Btw this issue has been previously also discussed here: https://github.com/orgs/OE4T/discussions/1470