### PR TITLE
tegra-storage-layout: Set S to UNPACKDIR

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-storage-layout_36.4.4.bb
+++ b/recipes-bsp/tegra-binaries/tegra-storage-layout_36.4.4.bb
@@ -12,6 +12,8 @@ PARTITION_FILE_EXTERNAL ?= "${STAGING_DATADIR}/l4t-storage-layout/${PARTITION_LA
 EXTRA_XML_SPLIT_ARGS = "--change-device-type=sdcard"
 PATH =. "${STAGING_BINDIR_NATIVE}/tegra-flash:"
 
+S = "${UNPACKDIR}"
+
 # Applies any fixed, per-SoC rewrites.  Consult the flash.sh script
 # and conf files in the L4T kit for how these are derived.
 copy_in_flash_layout() {


### PR DESCRIPTION
Fixes
WARNING: tegra-storage-layout-36.4.4-r0 do_unpack: tegra-storage-layout: the directory ${UNPACKDIR}/${BP} (/mnt/b/yoe/master/build/tmp/work/p3737_0000_p3701_0005-yoe-linux/tegra-storage-layout/36.4.4/sources/tegra-storage-layout-36.4.4) pointed to by the S variable doesn't exist - please set S within the recipe to point to where the source has been unpacked to