### PR TITLE
nvidia-l4t-optee: update main deb checksum

### DIFF
--- a/recipes-bsp/tegra-binaries/nvidia-l4t-optee_36.4.4.bb
+++ b/recipes-bsp/tegra-binaries/nvidia-l4t-optee_36.4.4.bb
@@ -3,7 +3,7 @@ L4T_DEB_COPYRIGHT_MD5 = "76b3130e18f6d6dc3236584f2c985e43"
 require tegra-debian-libraries-common.inc
 
 DESCRIPTION = "Prebuilt OPTEE normal-world binaries"
-MAINSUM = "ed014c60512b5877680c1d5b8dda11e350fa48e25e78bbd58f809698a5baa016"
+MAINSUM = "be31583b67c27dbda8d11448641d1ec02fd4d2d500658a6ecd80c77c7d43334f"
 
 inherit systemd
 


### PR DESCRIPTION
Updated main checksum to match that of 36.4.4.