### PR TITLE
python3-tensorrt: uprev to version 10.13.3

### DIFF
--- a/external/meta-python/recipes-devtools/python3-tensorrt/python3-tensorrt/0001-Fixups-for-cross-building-in-OE.patch
+++ b/external/meta-python/recipes-devtools/python3-tensorrt/python3-tensorrt/0001-Fixups-for-cross-building-in-OE.patch
@@ -1,4 +1,4 @@
-From a007d9400002107b044774c688ac327f0df22fa2 Mon Sep 17 00:00:00 2001
+From 441423420991d8afced04b784ad21ef6170b744b Mon Sep 17 00:00:00 2001
 From: Matt Madison <matt@madison.systems>
 Date: Mon, 14 Oct 2024 02:19:11 -0700
 Subject: [PATCH] Fixups for cross building in OE
@@ -10,14 +10,14 @@ Signed-off-by: Matt Madison <matt@madison.systems>
  1 file changed, 5 deletions(-)
 
 diff --git a/python/CMakeLists.txt b/python/CMakeLists.txt
-index 49f5d8a1..9f891ffe 100644
+index 6666511d..4b003d20 100644
 --- a/python/CMakeLists.txt
 +++ b/python/CMakeLists.txt
-@@ -38,11 +38,6 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${TENSORRT_MODULE}/)
- set(CPP_STANDARD 14 CACHE STRING "CPP Standard Version")
+@@ -319,11 +319,6 @@ set(CPP_STANDARD
+     CACHE STRING "CPP Standard Version")
  set(CMAKE_CXX_STANDARD ${CPP_STANDARD})
- 
--if (NOT MSVC)
+
+-if(NOT MSVC)
 -    # This allows us to use TRT libs shipped with standalone wheels.
 -    set(CMAKE_SHARED_LINKER_FLAGS -Wl,-rpath=$ORIGIN:$ORIGIN/../${TENSORRT_MODULE}_libs)
 -endif()
@@ -25,3 +25,4 @@ index 49f5d8a1..9f891ffe 100644
  # -------- PATHS --------
  message(STATUS "EXT_PATH: ${EXT_PATH}")
  message(STATUS "TENSORRT_BUILD: ${TENSORRT_BUILD}")
+--

--- a/external/meta-python/recipes-devtools/python3-tensorrt/python3-tensorrt_10.13.3.bb
+++ b/external/meta-python/recipes-devtools/python3-tensorrt/python3-tensorrt_10.13.3.bb
@@ -10,12 +10,13 @@ COMPATIBLE_MACHINE = "(tegra)"
 inherit setuptools3 cmake cuda
 
 SRC_REPO = "github.com/NVIDIA/TensorRT.git;protocol=https"
-SRCBRANCH = "release/10.3"
+SRCBRANCH = "release/${PV}"
 SRC_URI = "gitsm://${SRC_REPO};branch=${SRCBRANCH} \
            file://0001-Fixups-for-cross-building-in-OE.patch \
-           "
-# v10.3.0 tag
-SRCREV = "c5b9de37f7ef9034e2efc621c664145c7c12436e"
+    "
+
+# v${PV} tag
+SRCREV = "94e2b9ef6d2cce74c76cdad499cca36cc4949197"
 
 OECMAKE_SOURCEPATH = "${S}/python"
 SETUPTOOLS_SETUP_PATH = "${B}"
@@ -29,16 +30,17 @@ CXXFLAGS += "${CUDA_CXXFLAGS}"
 
 do_configure() {
     cmake_do_configure
-    TRT_MAJOR=$(awk '/^#define NV_TENSORRT_MAJOR/ {print $3}' ${STAGING_INCDIR}/NvInferVersion.h)
-    TRT_MINOR=$(awk '/^#define NV_TENSORRT_MINOR/ {print $3}' ${STAGING_INCDIR}/NvInferVersion.h)
-    TRT_PATCH=$(awk '/^#define NV_TENSORRT_PATCH/ {print $3}' ${STAGING_INCDIR}/NvInferVersion.h)
-    TRT_BUILD=$(awk '/^#define NV_TENSORRT_BUILD/ {print $3}' ${STAGING_INCDIR}/NvInferVersion.h)
+    TRT_MAJOR=$(awk '/^#define TRT_MAJOR_ENTERPRISE/ {print $3}' ${STAGING_INCDIR}/NvInferVersion.h)
+    TRT_MINOR=$(awk '/^#define TRT_MINOR_ENTERPRISE/ {print $3}' ${STAGING_INCDIR}/NvInferVersion.h)
+    TRT_PATCH=$(awk '/^#define TRT_PATCH_ENTERPRISE/ {print $3}' ${STAGING_INCDIR}/NvInferVersion.h)
+    TRT_BUILD=$(awk '/^#define TRT_BUILD_ENTERPRISE/ {print $3}' ${STAGING_INCDIR}/NvInferVersion.h)
     TRT_VERSION=${TRT_MAJOR}.${TRT_MINOR}.${TRT_PATCH}.${TRT_BUILD}
     TRT_MAJMINPATCH=${TRT_MAJOR}.${TRT_MINOR}.${TRT_PATCH}
     varsubst() {
         sed -e "s|\#\#TENSORRT_VERSION\#\#|${TRT_VERSION}|g" \
 	    -e "s|\#\#TENSORRT_MAJMINPATCH\#\#|${TRT_MAJMINPATCH}|g" \
 	    -e "s|\#\#TENSORRT_PYTHON_VERSION\#\#|${TRT_MAJMINPATCH}|g" \
+	    -e "s|\#\#TENSORRT_PLUGIN_DISABLED\#\#|\"0\"|g" \
 	    -e "s|\#\#TENSORRT_MODULE\#\#|tensorrt|g" $1 >$2
     }
 


### PR DESCRIPTION
Current python3-tensorrt version failed to build. Uprev to new version and get a successful build.

Defines for versioning has changed in the project and is adjusted in the recipe. One new define 'TENSORRT_PLUGIN_DISABLED' is introduced and is hardcoded to "0" in recipe as it was before.