### PR TITLE
Fix for building gcc-for-nvcc-cross-canadian-aarch64

### DIFF
--- a/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc-common.inc
+++ b/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc-common.inc
@@ -142,3 +142,7 @@ remove_sysroot_paths_from_checksum_options () {
        sed -i "s@${DEBUG_PREFIX_MAP}@@g" ${B}/gcc/checksum-options
        sed -i "s@$stagingdir@$replacement@g" ${B}/gcc/checksum-options
 }
+
+cleanup_installed_include_fixed () {
+	find ${D}${libdir}/gcc/${TARGET_SYS}/${BINV}/include-fixed -type f -not -name "README" -not -name limits.h -not -name syslimits.h | xargs rm -f
+}

--- a/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc-cross-canadian.inc
+++ b/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc-cross-canadian.inc
@@ -169,6 +169,8 @@ do_install () {
 			done
 		done
 	done
+
+	cleanup_installed_include_fixed
 }
 
 ELFUTILS = "nativesdk-elfutils"

--- a/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc-cross.inc
+++ b/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc-cross.inc
@@ -114,7 +114,7 @@ do_install () {
 	cp ${S}/libquadmath/quadmath.h ${D}${libdir}/gcc/${TARGET_SYS}/${BINV}/include/
 	cp ${S}/libquadmath/quadmath_weak.h ${D}${libdir}/gcc/${TARGET_SYS}/${BINV}/include/
 
-	find ${D}${libdir}/gcc/${TARGET_SYS}/${BINV}/include-fixed -type f -not -name "README" -not -name limits.h -not -name syslimits.h | xargs rm -f
+	cleanup_installed_include_fixed
 
 }
 

--- a/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc-target.inc
+++ b/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc-target.inc
@@ -184,37 +184,8 @@ do_install () {
 	ln -sf g++-${BINV} c++-${BINV}
 	ln -sf gcc-${BINV} cc-${BINV}
 	chown -R root:root ${D}
-}
 
-do_install:append () {
-        #
-        # Thefixinc.sh script, run on the gcc's compile phase, looks into sysroot header
-        # files and places the modified files into
-        # {D}${libdir}/gcc/${TARGET_SYS}/${BINV}/include-fixed folder. This makes the
-        # build not deterministic. The following code prunes all those headers
-        # except those under include-fixed/linux, *limits.h and README, yielding
-        # the same include-fixed folders no matter what sysroot
-
-        include_fixed="${D}${libdir}/gcc/${TARGET_SYS}/${BINV}/include-fixed"
-        for f in $(find ${include_fixed} -type f); do
-                case $f in
-                */include-fixed/linux/*)
-                    continue
-                    ;;
-                */include-fixed/*limits.h)
-                    continue
-                    ;;
-                */include-fixed/README)
-                    continue
-                    ;;
-                *)
-                    # remove file and directory if empty
-                    bbdebug 2 "Pruning $f"
-                    rm $f
-                    find $(dirname $f) -maxdepth 0 -empty -exec rmdir {} \;
-                    ;;
-                esac
-        done
+	cleanup_installed_include_fixed
 }
 
 # Installing /usr/lib/gcc/* means we'd have two copies, one from gcc-cross


### PR DESCRIPTION
When trying to build `gcc-for-nvcc-cross-canadian-aarch64` it fails with:

```
ERROR: gcc-for-nvcc-cross-canadian-aarch64-13.2.0-r0 do_package_qa: QA Issue: File /usr/local/oe-sdk-hardcoded-buildpath/sysroots/x86_64-tdsdk-linux/usr/libexec/aarch64-oe4t-linux/gcc/aarch64-oe4t-linux/13.2.0/cc1plus in package gcc-for-nvcc-cross-canadian-aarch64 contains reference to TMPDIR [buildpaths]
ERROR: gcc-for-nvcc-cross-canadian-aarch64-13.2.0-r0 do_package_qa: QA Issue: File /usr/local/oe-sdk-hardcoded-buildpath/sysroots/x86_64-tdsdk-linux/usr/libexec/aarch64-oe4t-linux/gcc/aarch64-oe4t-linux/13.2.0/cc1 in package gcc-for-nvcc-cross-canadian-aarch64 contains reference to TMPDIR [buildpaths]
ERROR: gcc-for-nvcc-cross-canadian-aarch64-13.2.0-r0 do_package_qa: QA Issue: File /usr/local/oe-sdk-hardcoded-buildpath/sysroots/x86_64-tdsdk-linux/usr/libexec/aarch64-oe4t-linux/gcc/aarch64-oe4t-linux/13.2.0/lto1 in package gcc-for-nvcc-cross-canadian-aarch64 contains reference to TMPDIR [buildpaths]
ERROR: gcc-for-nvcc-cross-canadian-aarch64-13.2.0-r0 do_package_qa: QA Issue: File /usr/local/oe-sdk-hardcoded-buildpath/sysroots/x86_64-tdsdk-linux/usr/bin/aarch64-oe4t-linux/aarch64-oe4t-linux-cpp-13.2.0 in package gcc-for-nvcc-cross-canadian-aarch64 contains reference to TMPDIR [buildpaths]
ERROR: gcc-for-nvcc-cross-canadian-aarch64-13.2.0-r0 do_package_qa: QA Issue: File /usr/local/oe-sdk-hardcoded-buildpath/sysroots/x86_64-tdsdk-linux/usr/bin/aarch64-oe4t-linux/aarch64-oe4t-linux-lto-dump-13.2.0 in package gcc-for-nvcc-cross-canadian-aarch64 contains reference to TMPDIR [buildpaths]
ERROR: gcc-for-nvcc-cross-canadian-aarch64-13.2.0-r0 do_package_qa: QA Issue: File /usr/local/oe-sdk-hardcoded-buildpath/sysroots/x86_64-tdsdk-linux/usr/bin/aarch64-oe4t-linux/aarch64-oe4t-linux-g++-13.2.0 in package gcc-for-nvcc-cross-canadian-aarch64 contains reference to TMPDIR [buildpaths]
ERROR: gcc-for-nvcc-cross-canadian-aarch64-13.2.0-r0 do_package_qa: QA Issue: File /usr/local/oe-sdk-hardcoded-buildpath/sysroots/x86_64-tdsdk-linux/usr/bin/aarch64-oe4t-linux/aarch64-oe4t-linux-c++-13.2.0 in package gcc-for-nvcc-cross-canadian-aarch64 contains reference to TMPDIR [buildpaths]
ERROR: gcc-for-nvcc-cross-canadian-aarch64-13.2.0-r0 do_package_qa: QA Issue: File /usr/local/oe-sdk-hardcoded-buildpath/sysroots/x86_64-tdsdk-linux/usr/lib/aarch64-oe4t-linux/gcc/aarch64-oe4t-linux/13.2.0/plugin/include/configargs.h in package gcc-for-nvcc-cross-canadian-aarch64 contains reference to TMPDIR [buildpaths]
ERROR: gcc-for-nvcc-cross-canadian-aarch64-13.2.0-r0 do_package_qa: QA Issue: File /usr/local/oe-sdk-hardcoded-buildpath/sysroots/x86_64-tdsdk-linux/usr/lib/aarch64-oe4t-linux/gcc/aarch64-oe4t-linux/13.2.0/include-fixed/pthread.h in package gcc-for-nvcc-cross-canadian-aarch64 contains reference to TMPDIR [buildpaths]
ERROR: gcc-for-nvcc-cross-canadian-aarch64-13.2.0-r0 do_package_qa: Fatal QA errors were found, failing task.
ERROR: Logfile of failure stored in: /work/yocto/tegra-demo-distro/build/tmp/work/x86_64-nativesdk-tdsdk-linux/gcc-for-nvcc-cross-canadian-aarch64/13.2.0/temp/log.do_package_qa.3028253
ERROR: Task (/work/yocto/tegra-demo-distro/layers/meta-tegra/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc-cross-canadian_13.2.bb:do_package_qa) failed with exit code '1'
```

This PR backports/picks up two patches from gcc in oe-core to mitigate this and make it build. References to original commits in commit messages.