### PR TITLE
edk2-firmware: add mirror for subhook submodule

### DIFF
--- a/recipes-bsp/uefi/edk2-firmware.inc
+++ b/recipes-bsp/uefi/edk2-firmware.inc
@@ -20,6 +20,10 @@ SRC_URI = "\
     ${SRC_URI_EDK2_PLATFORMS};branch=${SRCBRANCH_edk2};name=edk2-platforms;destsuffix=edk2/edk2-platforms \
 "
 
+EDK2_SUBHOOK_MIRROR_SPEC ?= "gitsm://github.com/Zeex/subhook.git gitsm://github.com/tianocore/edk2-subhook.git"
+PREMIRRORS =+ "${EDK2_SUBHOOK_MIRROR_SPEC}"
+MIRRORS += "${EDK2_SUBHOOK_MIRROR_SPEC}"
+
 SRCREV_FORMAT         = "edk2_edk2-platforms"
 UPSTREAM_CHECK_GITTAGREGEX = "^edk2-stable(?P<pver>\d+)$"
 


### PR DESCRIPTION
See https://github.com/tianocore/edk2/pull/6402 for more information. Until that change is merged into this branch in NVIDIA's clone of the edk2 repo, we can point PREMIRRORS and MIRRORS to the tianocore
mirror of the subrepo that has disappeared.

Fixes #2059 
