### PR TITLE
Add QSPI overlay for L4T 36.x

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-binaries-36.4.4.inc
+++ b/recipes-bsp/tegra-binaries/tegra-binaries-36.4.4.inc
@@ -4,9 +4,11 @@ LIC_FILES_CHKSUM = "file://Tegra_Software_License_Agreement-Tegra-Linux.txt;md5=
 
 SRC_URI = "\
     ${L4T_URI_BASE}/${L4T_BSP_PREFIX}_Linux_R${L4T_VERSION}_aarch64.tbz2 \
+    https://developer.nvidia.com/downloads/embedded/L4T/overlay_mb1bct_36.x.tbz2;name=qspi \
 "
 
 SRC_URI[sha256sum] = "a6ce11c22100ab0976e419959182417c83d62f4272501bc8714f2e076e010f3b"
+SRC_URI[qspi.sha256sum] = "c1b9051493c31168c58b0c3a4560d275a058c06657a580db840fe9a2600a3285"
 
 inherit l4t_bsp dos2unix
 


### PR DESCRIPTION
From field bulletin: https://forums.developer.nvidia.com/t/jetson-orin-and-jetson-thor-field-bulletins/351992/2