### PR TITLE
nvidia-kernel-oot: bump SRCREV

### DIFF
--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot_git.bb
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot_git.bb
@@ -1,7 +1,7 @@
 SRC_REPO = "github.com/OE4T/nvidia-kernel-oot;protocol=https"
 SRC_URI = "gitsm://${SRC_REPO};branch=${SRCBRANCH}"
 SRCBRANCH = "main"
-SRCREV = "0fd1438b4e001b658d733d6a1780286e43738ae4"
+SRCREV = "84d62bcc040f3e55b5d0cc7288daf6870367db6a"
 PV = "36.4.4+git"
 
 require nvidia-kernel-oot.inc


### PR DESCRIPTION
for back-porting a patch for cleaning up unused legacy driver code.

Fixes #2077 