### PR TITLE
nvidia-kernel-oot: update branch and SRCREV

### DIFF
--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot_git.bb
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot_git.bb
@@ -1,7 +1,7 @@
 SRC_REPO = "github.com/OE4T/nvidia-kernel-oot;protocol=https"
 SRC_URI = "gitsm://${SRC_REPO};branch=${SRCBRANCH}"
-SRCBRANCH = "main"
-SRCREV = "92c7803bcf2e6ce7f12a69ca5570c36095518d94"
+SRCBRANCH = "patches-rel-36"
+SRCREV = "a94b44e97f04bd1c5171837dfe6fe3b53402e71c"
 PV = "36.4.3+git"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
for picking up the nvadsp patch.

For #2077