### PR TITLE
tegra-helper-scripts: Add prerequisite checks and improve user feedback

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
@@ -96,6 +96,23 @@ while true; do
     esac
 done
 
+check_prerequisites() {
+    local missing=0
+
+    # Required: udisksctl (from udisks2 package)
+    if ! command -v udisksctl >/dev/null 2>&1; then
+        echo "ERR: 'udisksctl' command not found." >&2
+        echo "     Please install the 'udisks2' package." >&2
+        missing=1
+    fi
+
+    if [ $missing -ne 0 ]; then
+        exit 1
+    fi
+}
+
+check_prerequisites
+
 if [ -n "$PRESIGNED" ]; then
     if [ -n "$keyfile" -o -n "$sbk_keyfile" ]; then
 	echo "WARN: binaries already signed; ignoring signing options" >&2


### PR DESCRIPTION
Add early prerequisite validation to flashing scripts to fail fast with clear error messages when required tools are missing, and provide informational feedback when optional tools are not available.

`make-sdcard.sh`:
* Add `check_prerequisites()` for required tools
* Validate `sgdisk` (partitioning), `udisksctl` (USB ops)
* Check `bmaptool` (optional); show INFO if missing and fallback to `dd`
* Move `sgdisk` check earlier

`initrd-flash.sh`:
* Add `check_prerequisites()` for `udisksctl`