### PR TITLE
cuda: add support for 12.9

### DIFF
--- a/recipes-devtools/cuda/cuda-cccl-12-9_12.9.27-1.bb
+++ b/recipes-devtools/cuda/cuda-cccl-12-9_12.9.27-1.bb
@@ -1,0 +1,14 @@
+CUDA_PKG = "cuda-cccl"
+
+require cuda-shared-binaries-12.9.inc
+
+MAINSUM = "36349345a9e20d48fb2d202320ea1710223e732f9220b3c039531555cec3b77c"
+MAINSUM:x86-64 = "255b92bd5e09cd10aedaf098d1ee0f66ca1a9062efe96e2e1f385583ddf18c73"
+
+FILES:${PN} = " \
+    ${prefix}/local/cuda-${CUDA_VERSION}/include \
+    ${prefix}/local/cuda-${CUDA_VERSION}/lib \
+"
+FILES:${PN}-dev = ""
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/cuda/cuda-command-line-tools-12-9_12.9.1-1.bb
+++ b/recipes-devtools/cuda/cuda-command-line-tools-12-9_12.9.1-1.bb
@@ -1,0 +1,22 @@
+DESCRIPTION = "Dummy recipe for bringing in CUDA command-line tools"
+LICENSE = "MIT"
+
+PR = "r1"
+
+CUDA_COMPONENTS = "cuda-cupti-12-9 cuda-gdb-12-9 cuda-nvdisasm-12-9 cuda-nvtx-12-9 cuda-sanitizer-12-9"
+DEPENDS = "${CUDA_COMPONENTS}"
+
+do_fetch[noexec] = "1"
+do_unpack[noexec] = "1"
+do_patch[noexec] = "1"
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
+do_install[noexec] = "1"
+
+COMPATIBLE_MACHINE:class-target = "tegra"
+PACKAGE_ARCH:class-target = "${TEGRA_PKGARCH}"
+
+PACKAGES = "${PN} ${PN}-dev"
+ALLOW_EMPTY:${PN} = "1"
+RDEPENDS:${PN} = "${CUDA_COMPONENTS}"
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/cuda/cuda-compat-12-9_12.9.40580548-1.bb
+++ b/recipes-devtools/cuda/cuda-compat-12-9_12.9.40580548-1.bb
@@ -1,0 +1,12 @@
+CUDA_PKG = "cuda-compat"
+
+DEPENDS:tegra = "tegra-libraries-cuda"
+
+require cuda-shared-binaries-12.9.inc
+
+MAINSUM = "36f3cd8f5b89b2c539a5e13e0eb5a3e5d860b9e2fe567a2ba0651b0e477e127c"
+
+FILES:${PN} += "${prefix}/local/cuda-${CUDA_VERSION}/compat"
+
+RDEPENDS:${PN} = "tegra-libraries-cuda"
+INSANE_SKIP:${PN} += "dev-so"

--- a/recipes-devtools/cuda/cuda-compiler-12-9_12.9.1-1.bb
+++ b/recipes-devtools/cuda/cuda-compiler-12-9_12.9.1-1.bb
@@ -1,0 +1,22 @@
+DESCRIPTION = "Dummy recipe for bringing in CUDA compilation tools"
+LICENSE = "MIT"
+
+PR = "r1"
+
+CUDA_COMPONENTS = "cuda-cuobjdump-12-9 cuda-cuxxfilt-12-9 cuda-nvcc-12-9 cuda-nvprune-12-9"
+DEPENDS = "${CUDA_COMPONENTS}"
+
+do_fetch[noexec] = "1"
+do_unpack[noexec] = "1"
+do_patch[noexec] = "1"
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
+do_install[noexec] = "1"
+
+COMPATIBLE_MACHINE:class-target = "tegra"
+PACKAGE_ARCH:class-target = "${TEGRA_PKGARCH}"
+
+PACKAGES = "${PN} ${PN}-dev"
+ALLOW_EMPTY:${PN} = "1"
+RDEPENDS:${PN} = "${CUDA_COMPONENTS}"
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/cuda/cuda-crt-12-9_12.9.86-1.bb
+++ b/recipes-devtools/cuda/cuda-crt-12-9_12.9.86-1.bb
@@ -1,0 +1,10 @@
+CUDA_PKG = "cuda-crt"
+L4T_DEB_GROUP = "cuda-nvcc"
+
+require cuda-shared-binaries-12.9.inc
+
+MAINSUM = "3580531b3cf768220942f2f5c21b99e82889479ad1b1ea96b2e4eecf46c984b1"
+MAINSUM:x86-64 = "364c82d5fd53b6687aca004c4583fd119a98e0fe72798d88b0fdedc56ad5aecf"
+
+ALLOW_EMPTY:${PN} = "1"
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/cuda/cuda-cudart-12-9_12.9.79-1.bb
+++ b/recipes-devtools/cuda/cuda-cudart-12-9_12.9.79-1.bb
@@ -1,0 +1,34 @@
+CUDA_PKG = "cuda-cudart cuda-cudart-dev"
+
+DEPENDS = "cuda-driver-12-9 cuda-nvcc-headers-12-9 cuda-cccl-12-9 cuda-crt-12-9"
+
+require cuda-shared-binaries-12.9.inc
+
+MAINSUM = "a01ed9953693fa52a1ec83386d7cacf91818217d819ab4747f0ec45ac47e9854"
+MAINSUM:x86-64 = "2649df5457dcf9a741f979b5c71e09aba563a11ef1c84a0725c3fe7a37625e6e"
+DEVSUM = "9de59d51abf4ea2942967869d263f22718651a3e58534b6d0afdc9c012dc342d"
+DEVSUM:x86-64 = "e3ca8561b6bec2a92928ebafd68ed9278bf66d5521a2584d6370792386b247c0"
+
+
+inherit siteinfo
+
+do_compile:append() {
+    echo "${prefix}/local/cuda-${CUDA_VERSION}/${baselib}" > ${B}/cuda-${CUDA_VERSION_DASHED}.conf
+    if [ "${baselib}" != "lib64" -a "${SITEINFO_BITS}" = "64" ]; then
+	if [ -e ${B}/usr/local/cuda-${CUDA_VERSION}/${baselib} ]; then
+            ln -s ${baselib} ${B}/usr/local/cuda-${CUDA_VERSION}/lib64
+	fi
+    fi
+}
+
+do_install:append:class-target() {
+    install -d ${D}${sysconfdir}/ld.so.conf.d
+    install -m 0644 ${B}/cuda-${CUDA_VERSION_DASHED}.conf ${D}${sysconfdir}/ld.so.conf.d/
+}
+
+FILES:${PN}-dev += "${prefix}/local/cuda-${CUDA_VERSION}/${baselib}/*.a \
+                    ${@' ${prefix}/local/cuda-${CUDA_VERSION}/lib64' if d.getVar('baselib') != 'lib64' and d.getVar('SITEINFO_BITS') == '64' else ''}"
+FILES:${PN}-staticdev = ""
+INSANE_SKIP:${PN}-dev += "staticdev"
+RDEPENDS:${PN}-dev:append:class-target = " cuda-nvcc-headers cuda-cccl cuda-target-environment cuda-crt-dev"
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/cuda/cuda-cuobjdump-12-9_12.9.82-1.bb
+++ b/recipes-devtools/cuda/cuda-cuobjdump-12-9_12.9.82-1.bb
@@ -1,0 +1,7 @@
+CUDA_PKG = "cuda-cuobjdump"
+
+require cuda-shared-binaries-12.9.inc
+
+MAINSUM = "d2aae7c146c1a64a08df802c2328f2aaa7d68744f2a5b4344c5c1a8f0924b0e8"
+MAINSUM:x86-64 = "c2442f96785b9d06818e4d4edc1a2612227da14450c2ac704db7c97239116782"
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/cuda/cuda-cupti-12-9_12.9.79-1.bb
+++ b/recipes-devtools/cuda/cuda-cupti-12-9_12.9.79-1.bb
@@ -1,0 +1,13 @@
+CUDA_PKG = "cuda-cupti cuda-cupti-dev"
+
+require cuda-shared-binaries-12.9.inc
+
+MAINSUM = "56ec1f2b513a2055556fb0df4e56dd3e6168fe86d8f9705096bb71e0318ece72"
+MAINSUM:x86-64 = "a9b48ff6da29ff0f20cd582070ed66f36e9ae971157316bfdf780a9ac9ad6de8"
+DEVSUM = "a5266bcb145c1d9f03a6036d72c505357838e3be44a91fa45c80256b55fee2be"
+DEVSUM:x86-64 = "a5300e7356dbe4e70dfa8faa987febbf96b46946ca4cfb07baa9d5ea18de6bb6"
+
+FILES:${PN}-dev += "${prefix}/local/cuda-${CUDA_VERSION}/extras/CUPTI"
+RDEPENDS:${PN}-dev += "make perl perl-module-getopt-long perl-module-posix perl-module-cwd"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/cuda/cuda-cuxxfilt-12-9_12.9.82-1.bb
+++ b/recipes-devtools/cuda/cuda-cuxxfilt-12-9_12.9.82-1.bb
@@ -1,0 +1,8 @@
+CUDA_PKG = "cuda-cuxxfilt"
+
+require cuda-shared-binaries-12.9.inc
+
+MAINSUM = "0e869291ac1055cd53304d60a065b95610f6b6aeebc34417738a20124e1f3f62"
+MAINSUM:x86-64 = "d3431fdaa151eaa8bdebb96f847f878355dbf314ae15ea0c53a09d46a7682558"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/cuda/cuda-driver-12-9_12.9.79-1.bb
+++ b/recipes-devtools/cuda/cuda-driver-12-9_12.9.79-1.bb
@@ -1,0 +1,15 @@
+CUDA_PKG = "cuda-driver-dev"
+
+require cuda-shared-binaries-12.9.inc
+
+DEPENDS:tegra = "tegra-libraries-cuda tegra-cuda-utils"
+
+L4T_DEB_GROUP = "cuda-cudart"
+DEVSUM = "0fc12ca4745fe1437beee52f31bcec2b932e34810034b35176dd6e8a2c909d93"
+DEVSUM:x86-64 = "5fece9ec181860350dbda0e6368cee79797c6f00f9a44f376d241a1889e5608b"
+
+ALLOW_EMPTY:${PN} = "1"
+EXCLUDE_PACKAGES_FROM_SHLIBS = ""
+PRIVATE_LIBS = "libcuda.so.1"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/cuda/cuda-gdb-12-9_12.9.79-1.bb
+++ b/recipes-devtools/cuda/cuda-gdb-12-9_12.9.79-1.bb
@@ -1,0 +1,18 @@
+CUDA_PKG = "cuda-gdb"
+
+require cuda-shared-binaries-12.9.inc
+
+MAINSUM = "9356b3e9ae78ba0a7cefbc81ce0623916b6ee4d85267011d79da36602476e99c"
+MAINSUM:x86-64 = "f3a7d07c68a70fbbfda5574bd1fc0d151c682bae386c0be6d708afdc0b94980f"
+
+DEPENDS = "ncurses expat"
+
+do_compile:append() {
+    sed -i -r -e 's,^(\s*)print (.*)$,\1print(\2),' ${B}/usr/local/cuda-${CUDA_VERSION}/share/gdb/system-gdbinit/*.py
+}
+
+FILES:${PN}-dev += "${prefix}/local/cuda-${CUDA_VERSION}/share/gdb"
+RDEPENDS:${PN} += "gmp"
+RDEPENDS:${PN}-dev += "python3"
+INSANE_SKIP:${PN}-dev += "staticdev"
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/cuda/cuda-libraries-12-9_12.9.1-1.bb
+++ b/recipes-devtools/cuda/cuda-libraries-12-9_12.9.1-1.bb
@@ -1,0 +1,36 @@
+DESCRIPTION = "Dummy recipe for bringing in CUDA libraries"
+LICENSE = "MIT"
+
+CUDA_COMPONENTS = " \
+    cuda-cudart-12-9 \
+    cuda-nvrtc-12-9 \
+    libcublas-12-9 \
+    libcufft-12-9 \
+    libcufile-12-9 \
+    libcurand-12-9 \
+    libcusolver-12-9 \
+    libcusparse-12-9 \
+    libnpp-12-9 \
+    libnvjitlink-12-9 \
+    libnvfatbin-12-9 \
+"
+CUDA_COMPONENTS:append:class-target = " \
+    libcudla-12-9 \
+"
+DEPENDS = "${CUDA_COMPONENTS}"
+
+do_fetch[noexec] = "1"
+do_unpack[noexec] = "1"
+do_patch[noexec] = "1"
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
+do_install[noexec] = "1"
+
+COMPATIBLE_MACHINE:class-target = "tegra"
+PACKAGE_ARCH:class-target = "${TEGRA_PKGARCH}"
+
+PACKAGES = "${PN} ${PN}-dev"
+ALLOW_EMPTY:${PN} = "1"
+RDEPENDS:${PN} = "${CUDA_COMPONENTS}"
+RDEPENDS:${PN}-dev = "${@' '.join(['%s-dev' % pkg for pkg in d.getVar('CUDA_COMPONENTS').split()])} cuda-nvml-12-9-dev cuda-nvcc-headers-12-9 cuda-cccl-12-9 cuda-crt-12-9"
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/cuda/cuda-nvcc-12-9_12.9.86-1.bb
+++ b/recipes-devtools/cuda/cuda-nvcc-12-9_12.9.86-1.bb
@@ -1,0 +1,22 @@
+CUDA_PKG = "cuda-nvcc"
+
+require cuda-shared-binaries-12.9.inc
+
+DEPENDS = "cuda-cudart-12-9 cuda-nvvm-12-9 cuda-crt-12-9"
+
+MAINSUM = "337b9720ba0d71a3da4502a0f82e0f132a5edc7629b04275a191efb131c60617"
+MAINSUM:x86-64 = "66c11ad4fba8c12c44a1fec346c5125011e2ed519b98a787966dda0df9043b45"
+
+# header files are populated by cuda-nvcc-headers-12-9 recipes
+do_install:append() {
+    rm -rf ${D}${prefix}/local/cuda-${CUDA_VERSION}/include
+}
+
+FILES:${PN} = "${prefix}/local/cuda-${CUDA_VERSION}"
+FILES:${PN}-dev = ""
+INSANE_SKIP:${PN} += "dev-so dev-deps"
+RDEPENDS:${PN} = "cuda-nvcc-headers-12-9"
+RDEPENDS:${PN}:append:class-target = " cuda-nvvm-12-9-dev cuda-crt-12-9-dev"
+RDEPENDS:${PN}:append:class-nativesdk = " nativesdk-cuda-environment nativesdk-cuda-nvvm-12-9"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/cuda/cuda-nvcc-headers-12-9_12.9.86-1.bb
+++ b/recipes-devtools/cuda/cuda-nvcc-headers-12-9_12.9.86-1.bb
@@ -1,0 +1,18 @@
+CUDA_PKG = "cuda-nvcc"
+
+require cuda-shared-binaries-12.9.inc
+
+L4T_DEB_GROUP = "cuda-nvcc"
+MAINSUM = "337b9720ba0d71a3da4502a0f82e0f132a5edc7629b04275a191efb131c60617"
+MAINSUM:x86-64 = "66c11ad4fba8c12c44a1fec346c5125011e2ed519b98a787966dda0df9043b45"
+
+do_install:append() {
+    for d in bin lib nvvm nvvmx; do
+        rm -rf ${D}${prefix}/local/cuda-${CUDA_VERSION}/$d
+    done
+}
+
+FILES:${PN} = "${prefix}/local/cuda-${CUDA_VERSION}/include"
+FILES:${PN}-dev = ""
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/cuda/cuda-nvdisasm-12-9_12.9.88-1.bb
+++ b/recipes-devtools/cuda/cuda-nvdisasm-12-9_12.9.88-1.bb
@@ -1,0 +1,8 @@
+CUDA_PKG = "cuda-nvdisasm"
+
+require cuda-shared-binaries-12.9.inc
+
+MAINSUM = "57f05c7d28eb69add070dcb5a7ba5183f26d25dbd38cfc89853e49c87d44cc96"
+MAINSUM:x86-64 = "e2d186f399f4d8c2740b59bffde397b8a1bb5d344cfdf91355e7af10e3a9f3db"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/cuda/cuda-nvml-12-9_12.9.79-1.bb
+++ b/recipes-devtools/cuda/cuda-nvml-12-9_12.9.79-1.bb
@@ -1,0 +1,17 @@
+CUDA_PKG = "cuda-nvml-dev"
+
+require cuda-shared-binaries-12.9.inc
+
+DEPENDS:tegra = "tegra-libraries-nvml"
+
+L4T_DEB_GROUP = "cuda-nvml-dev"
+DEVSUM = "ef72570ae398ffdc0cdc4d051e0e41aa58c2b34db351166be0269b2d9e1efb6c"
+DEVSUM:x86-64 = "b26e97a445f6a0f587b8b6e2118907d09db1e77ecb5095b921555aa4ea95c585"
+
+ALLOW_EMPTY:${PN} = "1"
+FILES:${PN}-dev += "${prefix}/local/cuda-${CUDA_VERSION}/nvml/example"
+EXCLUDE_PACKAGES_FROM_SHLIBS = ""
+PRIVATE_LIBS = "libnvidia-ml.so.1"
+INSANE_SKIP:${PN}-stubs += "staticdev"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/cuda/cuda-nvprof-12-9_12.9.79-1.bb
+++ b/recipes-devtools/cuda/cuda-nvprof-12-9_12.9.79-1.bb
@@ -1,0 +1,11 @@
+CUDA_PKG = "cuda-nvprof"
+
+require cuda-shared-binaries-12.9.inc
+
+COMPATIBLE_HOST:tegra = "(-)"
+
+MAINSUM = "1ae8ec482368cbe2540c6b234375a3b957fe9a1301a259f482f207c98abeff1c"
+
+DEPENDS = "cuda-cupti-12-9"
+ALLOW_EMPTY:${PN} = "1"
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/cuda/cuda-nvprune-12-9_12.9.82-1.bb
+++ b/recipes-devtools/cuda/cuda-nvprune-12-9_12.9.82-1.bb
@@ -1,0 +1,8 @@
+CUDA_PKG = "cuda-nvprune"
+
+require cuda-shared-binaries-12.9.inc
+
+MAINSUM = "6c159246ab6baf7fa19fc3bdb17d454a61bf9ea6a27aa0652ab45fd3e44b742b"
+MAINSUM:x86-64 = "06a9dea23acaed7deec711149f5d96915d9a8611909922b32346e8799812c1cb"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/cuda/cuda-nvrtc-12-9_12.9.86-1.bb
+++ b/recipes-devtools/cuda/cuda-nvrtc-12-9_12.9.86-1.bb
@@ -1,0 +1,14 @@
+CUDA_PKG = "cuda-nvrtc cuda-nvrtc-dev"
+
+require cuda-shared-binaries-12.9.inc
+
+MAINSUM = "57cd5a9792be281992301e186648b925fc29d3e7c1e090cf53ccde15456c5275"
+MAINSUM:x86-64 = "4e1cc14cc3578dd69286d9ac6a0623297e854ba09539b1780b6989d2199395af"
+DEVSUM = "86a05125718af2613b342f57b353f5bee185bbb7c81afe807d019cb004af87aa"
+DEVSUM:x86-64 = "737a64f295cd74d4d3f7df4e195544938c9091c52d6e768a884922fdc1b1bc97"
+
+FILES:${PN}-dev:remove = "${prefix}/local/cuda-${CUDA_VERSION}/${baselib}/*${SOLIBSDEV}"
+FILES:${PN} += "${prefix}/local/cuda-${CUDA_VERSION}/${baselib}/libnvrtc-builtins.so"
+FILES:${PN}-dev += "${prefix}/local/cuda-${CUDA_VERSION}/${baselib}/libnvrtc.so"
+INSANE_SKIP:${PN} += "dev-so"
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/cuda/cuda-nvtx-12-9_12.9.79-1.bb
+++ b/recipes-devtools/cuda/cuda-nvtx-12-9_12.9.79-1.bb
@@ -1,0 +1,8 @@
+CUDA_PKG = "cuda-nvtx"
+
+require cuda-shared-binaries-12.9.inc
+
+MAINSUM = "a6a922aafc3ea41e6c0e43103c9ce351ecaafac478e84b956f02d1655250371c"
+MAINSUM:x86-64 = "285457dd2afaa8dffb7f79dfe974ca10bd88f026d7e2e18c34a6449e3d752e6c"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/cuda/cuda-nvvm-12-9_12.9.86-1.bb
+++ b/recipes-devtools/cuda/cuda-nvvm-12-9_12.9.86-1.bb
@@ -1,0 +1,13 @@
+CUDA_PKG = "cuda-nvvm"
+L4T_DEB_GROUP = "cuda-nvcc"
+
+require cuda-shared-binaries-12.9.inc
+
+MAINSUM = "522ddf467f317d242c17f9eeb78cb7b38339b21b6de3a175f49b4d966d55fba2"
+MAINSUM:x86-64 = "679b7fa53d30dcb7d2f5f55107274fa502ff18071c6c1235cb941fcbe22a1403"
+
+FILES:${PN} = "${prefix}/local/cuda-${CUDA_VERSION}"
+FILES:${PN}-dev = ""
+INSANE_SKIP:${PN} += "dev-so"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/cuda/cuda-profiler-api-12-9_12.9.79-1.bb
+++ b/recipes-devtools/cuda/cuda-profiler-api-12-9_12.9.79-1.bb
@@ -1,0 +1,9 @@
+CUDA_PKG = "cuda-profiler-api"
+
+require cuda-shared-binaries-12.9.inc
+
+MAINSUM = "c439f200325a6aab9cd41f5330bce946d858e54d1ea2b442d53d997fb43369ab"
+MAINSUM:x86-64 = "2777376d69c44db9e95073fb6991f8fcd770642ce49d90b9168994b9f2ae7664"
+
+ALLOW_EMPTY:${PN} = "1"
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/cuda/cuda-samples-12-9/0001-Updates-for-OE-cross-builds.patch
+++ b/recipes-devtools/cuda/cuda-samples-12-9/0001-Updates-for-OE-cross-builds.patch
@@ -1,0 +1,1070 @@
+From 0bd5ea990cfb27dd666b000fa1faa2f35f3d1b21 Mon Sep 17 00:00:00 2001
+From: Ilies CHERGUI <ichergui@nvidia.com>
+Date: Wed, 10 Dec 2025 17:16:35 +0000
+Subject: [PATCH] Updates for OE cross builds
+
+Upstream-Status: Inappropriate [oe-specific]
+
+Signed-off-by: Ilies CHERGUI <ichergui@nvidia.com>
+---
+ CMakeLists.txt                                |  8 --------
+ Samples/0_Introduction/CMakeLists.txt         | 20 -------------------
+ .../UnifiedMemoryStreams/CMakeLists.txt       | 18 +++++------------
+ .../0_Introduction/asyncAPI/CMakeLists.txt    | 12 ++---------
+ Samples/0_Introduction/clock/CMakeLists.txt   | 12 ++---------
+ .../0_Introduction/cudaOpenMP/CMakeLists.txt  | 16 ++++-----------
+ .../fp16ScalarProduct/CMakeLists.txt          | 11 ++--------
+ .../0_Introduction/matrixMul/CMakeLists.txt   | 12 ++---------
+ .../matrixMulDynlinkJIT/CMakeLists.txt        | 15 +++-----------
+ .../simpleAssert/CMakeLists.txt               | 12 ++---------
+ .../simpleAtomicIntrinsics/CMakeLists.txt     | 13 ++----------
+ .../simpleAttributes/CMakeLists.txt           | 12 ++---------
+ .../simpleCallback/CMakeLists.txt             | 12 ++---------
+ .../simpleCubemapTexture/CMakeLists.txt       | 12 ++---------
+ .../simpleLayeredTexture/CMakeLists.txt       | 12 ++---------
+ .../simpleMultiCopy/CMakeLists.txt            | 12 ++---------
+ .../simpleMultiGPU/CMakeLists.txt             | 12 ++---------
+ .../simpleOccupancy/CMakeLists.txt            | 12 ++---------
+ .../simplePitchLinearTexture/CMakeLists.txt   | 12 ++---------
+ .../simplePrintf/CMakeLists.txt               | 12 ++---------
+ .../simpleStreams/CMakeLists.txt              | 12 ++---------
+ .../simpleSurfaceWrite/CMakeLists.txt         | 13 +++---------
+ .../simpleTemplates/CMakeLists.txt            | 12 ++---------
+ .../simpleTexture/CMakeLists.txt              | 13 +++---------
+ .../simpleVoteIntrinsics/CMakeLists.txt       | 12 ++---------
+ .../simpleZeroCopy/CMakeLists.txt             | 12 ++---------
+ .../0_Introduction/vectorAdd/CMakeLists.txt   | 12 ++---------
+ Samples/1_Utilities/CMakeLists.txt            |  2 --
+ .../1_Utilities/deviceQuery/CMakeLists.txt    | 14 +++----------
+ Samples/6_Performance/CMakeLists.txt          |  4 ----
+ .../UnifiedMemoryPerf/CMakeLists.txt          | 12 ++---------
+ Samples/CMakeLists.txt                        | 19 ------------------
+ 32 files changed, 63 insertions(+), 331 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f95e7aae..c2727886 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -14,14 +14,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ set(CMAKE_CUDA_STANDARD 17)
+ set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+ 
+-set(CMAKE_CUDA_ARCHITECTURES 50 52 60 61 70 72 75 80 86 87 89 90 100 101 120)
+-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Wno-deprecated-gpu-targets")
+-if(ENABLE_CUDA_DEBUG)
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -G")        # enable cuda-gdb (may significantly affect performance on some targets)
+-else()
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -lineinfo") # add line information to all builds for debug tools (exclusive to -G option)
+-endif()
+-
+ set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --extended-lambda")
+ 
+ add_subdirectory(Samples)
+diff --git a/Samples/0_Introduction/CMakeLists.txt b/Samples/0_Introduction/CMakeLists.txt
+index 74534758..238a9b51 100644
+--- a/Samples/0_Introduction/CMakeLists.txt
++++ b/Samples/0_Introduction/CMakeLists.txt
+@@ -1,46 +1,26 @@
+ add_subdirectory(UnifiedMemoryStreams)
+ add_subdirectory(asyncAPI)
+ add_subdirectory(clock)
+-add_subdirectory(clock_nvrtc)
+ add_subdirectory(cudaOpenMP)
+ add_subdirectory(fp16ScalarProduct)
+ add_subdirectory(matrixMul)
+-add_subdirectory(matrixMulDrv)
+ add_subdirectory(matrixMulDynlinkJIT)
+-add_subdirectory(matrixMul_nvrtc)
+-add_subdirectory(mergeSort)
+-add_subdirectory(simpleAWBarrier)
+ add_subdirectory(simpleAssert)
+-add_subdirectory(simpleAssert_nvrtc)
+ add_subdirectory(simpleAtomicIntrinsics)
+-add_subdirectory(simpleAtomicIntrinsics_nvrtc)
+ add_subdirectory(simpleAttributes)
+-add_subdirectory(simpleCUDA2GL)
+ add_subdirectory(simpleCallback)
+-add_subdirectory(simpleCooperativeGroups)
+ add_subdirectory(simpleCubemapTexture)
+-add_subdirectory(simpleDrvRuntime)
+-add_subdirectory(simpleHyperQ)
+-add_subdirectory(simpleIPC)
+ add_subdirectory(simpleLayeredTexture)
+-add_subdirectory(simpleMPI)
+ add_subdirectory(simpleMultiCopy)
+ add_subdirectory(simpleMultiGPU)
+ add_subdirectory(simpleOccupancy)
+-add_subdirectory(simpleP2P)
+ add_subdirectory(simplePitchLinearTexture)
+ add_subdirectory(simplePrintf)
+ add_subdirectory(simpleStreams)
+ add_subdirectory(simpleSurfaceWrite)
+ add_subdirectory(simpleTemplates)
+ add_subdirectory(simpleTexture)
+-add_subdirectory(simpleTexture3D)
+-add_subdirectory(simpleTextureDrv)
+ add_subdirectory(simpleVoteIntrinsics)
+ add_subdirectory(simpleZeroCopy)
+ add_subdirectory(template)
+-add_subdirectory(systemWideAtomics)
+ add_subdirectory(vectorAdd)
+-add_subdirectory(vectorAddDrv)
+-add_subdirectory(vectorAddMMAP)
+-add_subdirectory(vectorAdd_nvrtc)
+diff --git a/Samples/0_Introduction/UnifiedMemoryStreams/CMakeLists.txt b/Samples/0_Introduction/UnifiedMemoryStreams/CMakeLists.txt
+index 090cfe2c..e8f0aec6 100644
+--- a/Samples/0_Introduction/UnifiedMemoryStreams/CMakeLists.txt
++++ b/Samples/0_Introduction/UnifiedMemoryStreams/CMakeLists.txt
+@@ -1,21 +1,11 @@
+ cmake_minimum_required(VERSION 3.20)
+ 
+-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/Modules")
+-
+ project(UnifiedMemoryStreams LANGUAGES C CXX CUDA)
+ 
+ find_package(CUDAToolkit REQUIRED)
+ 
+ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ 
+-set(CMAKE_CUDA_ARCHITECTURES 50 52 60 61 70 72 75 80 86 87 89 90 100 101 120)
+-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Wno-deprecated-gpu-targets")
+-if(ENABLE_CUDA_DEBUG)
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -G")        # enable cuda-gdb (may significantly affect performance on some targets)
+-else()
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -lineinfo") # add line information to all builds for debug tools (exclusive to -G option)
+-endif()
+-
+ # Include directories and libraries
+ include_directories(../../../Common)
+ 
+@@ -30,16 +20,18 @@ if(${OpenMP_FOUND})
+     # Add target for UnifiedMemoryStreams
+     add_executable(UnifiedMemoryStreams UnifiedMemoryStreams.cu)
+ 
+-target_compile_options(UnifiedMemoryStreams PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--extended-lambda>)
++    target_compile_options(UnifiedMemoryStreams PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--extended-lambda>)
+ 
+-target_compile_features(UnifiedMemoryStreams PRIVATE cxx_std_17 cuda_std_17)
++    target_compile_features(UnifiedMemoryStreams PRIVATE cxx_std_17 cuda_std_17)
+ 
+     set_target_properties(UnifiedMemoryStreams PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
+ 
+     target_link_libraries(UnifiedMemoryStreams PUBLIC
+-        CUDA::cublas
++        cublas
+         OpenMP::OpenMP_CXX
+     )
++
++    install(TARGETS UnifiedMemoryStreams RUNTIME DESTINATION ${CMAKE_INSTALL_CUDA_SAMPLES})
+ else()
+     message(STATUS "OpenMP not found - will not build sample 'UnifiedMemoryStreams'")
+ endif()
+diff --git a/Samples/0_Introduction/asyncAPI/CMakeLists.txt b/Samples/0_Introduction/asyncAPI/CMakeLists.txt
+index 6fed8cf7..c5b4afcb 100644
+--- a/Samples/0_Introduction/asyncAPI/CMakeLists.txt
++++ b/Samples/0_Introduction/asyncAPI/CMakeLists.txt
+@@ -1,21 +1,11 @@
+ cmake_minimum_required(VERSION 3.20)
+ 
+-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/Modules")
+-
+ project(asyncAPI LANGUAGES C CXX CUDA)
+ 
+ find_package(CUDAToolkit REQUIRED)
+ 
+ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ 
+-set(CMAKE_CUDA_ARCHITECTURES 50 52 60 61 70 72 75 80 86 87 89 90 100 101 120)
+-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Wno-deprecated-gpu-targets")
+-if(ENABLE_CUDA_DEBUG)
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -G")        # enable cuda-gdb (may significantly affect performance on some targets)
+-else()
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -lineinfo") # add line information to all builds for debug tools (exclusive to -G option)
+-endif()
+-
+ # Include directories and libraries
+ include_directories(../../../Common)
+ 
+@@ -28,3 +18,5 @@ target_compile_options(asyncAPI PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--extended-la
+ target_compile_features(asyncAPI PRIVATE cxx_std_17 cuda_std_17)
+ 
+ set_target_properties(asyncAPI PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
++
++install(TARGETS asyncAPI RUNTIME DESTINATION ${CMAKE_INSTALL_CUDA_SAMPLES})
+diff --git a/Samples/0_Introduction/clock/CMakeLists.txt b/Samples/0_Introduction/clock/CMakeLists.txt
+index 740f03e9..eec1ee59 100644
+--- a/Samples/0_Introduction/clock/CMakeLists.txt
++++ b/Samples/0_Introduction/clock/CMakeLists.txt
+@@ -1,21 +1,11 @@
+ cmake_minimum_required(VERSION 3.20)
+ 
+-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/Modules")
+-
+ project(clock LANGUAGES C CXX CUDA)
+ 
+ find_package(CUDAToolkit REQUIRED)
+ 
+ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ 
+-set(CMAKE_CUDA_ARCHITECTURES 50 52 60 61 70 72 75 80 86 87 89 90 100 101 120)
+-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Wno-deprecated-gpu-targets")
+-if(ENABLE_CUDA_DEBUG)
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -G")        # enable cuda-gdb (may significantly affect performance on some targets)
+-else()
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -lineinfo") # add line information to all builds for debug tools (exclusive to -G option)
+-endif()
+-
+ # Include directories and libraries
+ include_directories(../../../Common)
+ 
+@@ -28,3 +18,5 @@ target_compile_options(clock PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--extended-lambd
+ target_compile_features(clock PRIVATE cxx_std_17 cuda_std_17)
+ 
+ set_target_properties(clock PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
++
++install(TARGETS clock RUNTIME DESTINATION ${CMAKE_INSTALL_CUDA_SAMPLES})
+diff --git a/Samples/0_Introduction/cudaOpenMP/CMakeLists.txt b/Samples/0_Introduction/cudaOpenMP/CMakeLists.txt
+index 886e0838..01260e8d 100644
+--- a/Samples/0_Introduction/cudaOpenMP/CMakeLists.txt
++++ b/Samples/0_Introduction/cudaOpenMP/CMakeLists.txt
+@@ -1,21 +1,11 @@
+ cmake_minimum_required(VERSION 3.20)
+ 
+-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/Modules")
+-
+ project(cudaOpenMP LANGUAGES C CXX CUDA)
+ 
+ find_package(CUDAToolkit REQUIRED)
+ 
+ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ 
+-set(CMAKE_CUDA_ARCHITECTURES 50 52 60 61 70 72 75 80 86 87 89 90 100 101 120)
+-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Wno-deprecated-gpu-targets")
+-if(ENABLE_CUDA_DEBUG)
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -G")        # enable cuda-gdb (may significantly affect performance on some targets)
+-else()
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -lineinfo") # add line information to all builds for debug tools (exclusive to -G option)
+-endif()
+-
+ # Include directories and libraries
+ include_directories(../../../Common)
+ 
+@@ -26,14 +16,16 @@ if(OpenMP_CXX_FOUND)
+ # Add target for asyncAPI
+     add_executable(cudaOpenMP cudaOpenMP.cu)
+ 
+-target_compile_options(cudaOpenMP PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--extended-lambda>)
++    target_compile_options(cudaOpenMP PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--extended-lambda>)
+ 
+-target_compile_features(cudaOpenMP PRIVATE cxx_std_17 cuda_std_17)
++    target_compile_features(cudaOpenMP PRIVATE cxx_std_17 cuda_std_17)
+ 
+     set_target_properties(cudaOpenMP PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
+     target_link_libraries(cudaOpenMP PUBLIC
+         OpenMP::OpenMP_CXX
+     )
++
++    install(TARGETS cudaOpenMP RUNTIME DESTINATION ${CMAKE_INSTALL_CUDA_SAMPLES})
+ else()
+     message(STATUS "OpenMP not found - will not build sample 'cudaOpenMP'")
+ endif()
+diff --git a/Samples/0_Introduction/fp16ScalarProduct/CMakeLists.txt b/Samples/0_Introduction/fp16ScalarProduct/CMakeLists.txt
+index 4d265d49..f9334cd5 100644
+--- a/Samples/0_Introduction/fp16ScalarProduct/CMakeLists.txt
++++ b/Samples/0_Introduction/fp16ScalarProduct/CMakeLists.txt
+@@ -1,20 +1,11 @@
+ cmake_minimum_required(VERSION 3.20)
+ 
+-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/Modules")
+-
+ project(fp16ScalarProduct LANGUAGES C CXX CUDA)
+ 
+ find_package(CUDAToolkit REQUIRED)
+ 
+ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ 
+-set(CMAKE_CUDA_ARCHITECTURES 60 61 70 72 75 80 86 87 89 90 100 101 120)
+-if(ENABLE_CUDA_DEBUG)
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -G")        # enable cuda-gdb (may significantly affect performance on some targets)
+-else()
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -lineinfo") # add line information to all builds for debug tools (exclusive to -G option)
+-endif()
+-
+ # Include directories and libraries
+ include_directories(../../../Common)
+ 
+@@ -27,3 +18,5 @@ target_compile_options(fp16ScalarProduct PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--ex
+ target_compile_features(fp16ScalarProduct PRIVATE cxx_std_17 cuda_std_17)
+ 
+ set_target_properties(fp16ScalarProduct PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
++
++install(TARGETS fp16ScalarProduct RUNTIME DESTINATION ${CMAKE_INSTALL_CUDA_SAMPLES})
+diff --git a/Samples/0_Introduction/matrixMul/CMakeLists.txt b/Samples/0_Introduction/matrixMul/CMakeLists.txt
+index d0acc448..424b1a3e 100644
+--- a/Samples/0_Introduction/matrixMul/CMakeLists.txt
++++ b/Samples/0_Introduction/matrixMul/CMakeLists.txt
+@@ -1,21 +1,11 @@
+ cmake_minimum_required(VERSION 3.20)
+ 
+-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/Modules")
+-
+ project(matrixMul LANGUAGES C CXX CUDA)
+ 
+ find_package(CUDAToolkit REQUIRED)
+ 
+ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ 
+-set(CMAKE_CUDA_ARCHITECTURES 50 52 60 61 70 72 75 80 86 87 89 90 100 101 120)
+-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Wno-deprecated-gpu-targets")
+-if(ENABLE_CUDA_DEBUG)
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -G")        # enable cuda-gdb (may significantly affect performance on some targets)
+-else()
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -lineinfo") # add line information to all builds for debug tools (exclusive to -G option)
+-endif()
+-
+ # Include directories and libraries
+ include_directories(../../../Common)
+ 
+@@ -28,3 +18,5 @@ target_compile_options(matrixMul PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--extended-l
+ target_compile_features(matrixMul PRIVATE cxx_std_17 cuda_std_17)
+ 
+ set_target_properties(matrixMul PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
++
++install(TARGETS matrixMul RUNTIME DESTINATION ${CMAKE_INSTALL_CUDA_SAMPLES})
+diff --git a/Samples/0_Introduction/matrixMulDynlinkJIT/CMakeLists.txt b/Samples/0_Introduction/matrixMulDynlinkJIT/CMakeLists.txt
+index 6e4f044c..a20977ce 100644
+--- a/Samples/0_Introduction/matrixMulDynlinkJIT/CMakeLists.txt
++++ b/Samples/0_Introduction/matrixMulDynlinkJIT/CMakeLists.txt
+@@ -1,21 +1,11 @@
+ cmake_minimum_required(VERSION 3.20)
+ 
+-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/Modules")
+-
+ project(matrixMulDynlinkJIT LANGUAGES C CXX CUDA)
+ 
+ find_package(CUDAToolkit REQUIRED)
+ 
+ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ 
+-set(CMAKE_CUDA_ARCHITECTURES 50 52 60 61 70 72 75 80 86 87 89 90 100 101 120)
+-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Wno-deprecated-gpu-targets")
+-if(ENABLE_CUDA_DEBUG)
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -G")        # enable cuda-gdb (may significantly affect performance on some targets)
+-else()
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -lineinfo") # add line information to all builds for debug tools (exclusive to -G option)
+-endif()
+-
+ # Include directories and libraries
+ include_directories(../../../Common)
+ 
+@@ -33,10 +23,11 @@ set_target_properties(matrixMulDynlinkJIT PROPERTIES
+ )
+ set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -no-pie")
+ target_link_libraries(matrixMulDynlinkJIT PUBLIC
+-    CUDA::cudart
+-    CUDA::cuda_driver
++    cudart
+ )
+ 
+ if(UNIX)
+     target_link_libraries(matrixMulDynlinkJIT PUBLIC dl)
+ endif()
++
++install(TARGETS matrixMulDynlinkJIT RUNTIME DESTINATION ${CMAKE_INSTALL_CUDA_SAMPLES})
+diff --git a/Samples/0_Introduction/simpleAssert/CMakeLists.txt b/Samples/0_Introduction/simpleAssert/CMakeLists.txt
+index cf5e3729..78118a59 100644
+--- a/Samples/0_Introduction/simpleAssert/CMakeLists.txt
++++ b/Samples/0_Introduction/simpleAssert/CMakeLists.txt
+@@ -1,21 +1,11 @@
+ cmake_minimum_required(VERSION 3.20)
+ 
+-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/Modules")
+-
+ project(simpleAssert LANGUAGES C CXX CUDA)
+ 
+ find_package(CUDAToolkit REQUIRED)
+ 
+ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ 
+-set(CMAKE_CUDA_ARCHITECTURES 50 52 60 61 70 72 75 80 86 87 89 90 100 101 120)
+-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Wno-deprecated-gpu-targets")
+-if(ENABLE_CUDA_DEBUG)
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -G")        # enable cuda-gdb (may significantly affect performance on some targets)
+-else()
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -lineinfo") # add line information to all builds for debug tools (exclusive to -G option)
+-endif()
+-
+ # Removes -DNDEBUG For Print specific logs in this sample.
+ string(REPLACE "-DNDEBUG" "" CMAKE_CUDA_FLAGS_RELEASE "${CMAKE_CUDA_FLAGS_RELEASE}")
+ 
+@@ -31,3 +21,5 @@ target_compile_options(simpleAssert PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--extende
+ target_compile_features(simpleAssert PRIVATE cxx_std_17 cuda_std_17)
+ 
+ set_target_properties(simpleAssert PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
++
++install(TARGETS simpleAssert RUNTIME DESTINATION ${CMAKE_INSTALL_CUDA_SAMPLES})
+diff --git a/Samples/0_Introduction/simpleAtomicIntrinsics/CMakeLists.txt b/Samples/0_Introduction/simpleAtomicIntrinsics/CMakeLists.txt
+index 594aeb1e..ee309883 100644
+--- a/Samples/0_Introduction/simpleAtomicIntrinsics/CMakeLists.txt
++++ b/Samples/0_Introduction/simpleAtomicIntrinsics/CMakeLists.txt
+@@ -1,22 +1,11 @@
+ cmake_minimum_required(VERSION 3.20)
+ 
+-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/Modules")
+-
+ project(simpleAtomicIntrinsics LANGUAGES C CXX CUDA)
+ 
+ find_package(CUDAToolkit REQUIRED)
+ 
+ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ 
+-set(CMAKE_CUDA_ARCHITECTURES  50 52 60 61 70 72 75 80 86 87 89 90 100 101 120)
+-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Wno-deprecated-gpu-targets")
+-
+-if(ENABLE_CUDA_DEBUG)
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -G")        # enable cuda-gdb (may significantly affect performance on some targets)
+-else()
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -lineinfo") # add line information to all builds for debug tools (exclusive to -G option)
+-endif()
+-
+ # Include directories and libraries
+ include_directories(../../../Common)
+ 
+@@ -29,3 +18,5 @@ target_compile_options(simpleAtomicIntrinsics PRIVATE $<$<COMPILE_LANGUAGE:CUDA>
+ target_compile_features(simpleAtomicIntrinsics PRIVATE cxx_std_17 cuda_std_17)
+ 
+ set_target_properties(simpleAtomicIntrinsics PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
++
++install(TARGETS simpleAtomicIntrinsics RUNTIME DESTINATION ${CMAKE_INSTALL_CUDA_SAMPLES})
+diff --git a/Samples/0_Introduction/simpleAttributes/CMakeLists.txt b/Samples/0_Introduction/simpleAttributes/CMakeLists.txt
+index 92d61f7e..27f2a952 100644
+--- a/Samples/0_Introduction/simpleAttributes/CMakeLists.txt
++++ b/Samples/0_Introduction/simpleAttributes/CMakeLists.txt
+@@ -1,21 +1,11 @@
+ cmake_minimum_required(VERSION 3.20)
+ 
+-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/Modules")
+-
+ project(simpleAttributes LANGUAGES C CXX CUDA)
+ 
+ find_package(CUDAToolkit REQUIRED)
+ 
+ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ 
+-set(CMAKE_CUDA_ARCHITECTURES 50 52 60 61 70 72 75 80 86 87 89 90 100 101 120)
+-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Wno-deprecated-gpu-targets")
+-if(ENABLE_CUDA_DEBUG)
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -G")        # enable cuda-gdb (may significantly affect performance on some targets)
+-else()
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -lineinfo") # add line information to all builds for debug tools (exclusive to -G option)
+-endif()
+-
+ # Include directories and libraries
+ include_directories(../../../Common)
+ 
+@@ -28,3 +18,5 @@ target_compile_options(simpleAttributes PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--ext
+ target_compile_features(simpleAttributes PRIVATE cxx_std_17 cuda_std_17)
+ 
+ set_target_properties(simpleAttributes PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
++
++install(TARGETS simpleAttributes RUNTIME DESTINATION ${CMAKE_INSTALL_CUDA_SAMPLES})
+diff --git a/Samples/0_Introduction/simpleCallback/CMakeLists.txt b/Samples/0_Introduction/simpleCallback/CMakeLists.txt
+index 34b22185..3fe273d9 100644
+--- a/Samples/0_Introduction/simpleCallback/CMakeLists.txt
++++ b/Samples/0_Introduction/simpleCallback/CMakeLists.txt
+@@ -1,21 +1,11 @@
+ cmake_minimum_required(VERSION 3.20)
+ 
+-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/Modules")
+-
+ project(simpleCallback LANGUAGES C CXX CUDA)
+ 
+ find_package(CUDAToolkit REQUIRED)
+ 
+ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ 
+-set(CMAKE_CUDA_ARCHITECTURES 50 52 60 61 70 72 75 80 86 87 89 90 100 101 120)
+-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Wno-deprecated-gpu-targets")
+-if(ENABLE_CUDA_DEBUG)
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -G")        # enable cuda-gdb (may significantly affect performance on some targets)
+-else()
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -lineinfo") # add line information to all builds for debug tools (exclusive to -G option)
+-endif()
+-
+ # Include directories and libraries
+ include_directories(../../../Common)
+ 
+@@ -28,3 +18,5 @@ target_compile_options(simpleCallback PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--exten
+ target_compile_features(simpleCallback PRIVATE cxx_std_17 cuda_std_17)
+ 
+ set_target_properties(simpleCallback PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
++
++install(TARGETS simpleCallback RUNTIME DESTINATION ${CMAKE_INSTALL_CUDA_SAMPLES})
+diff --git a/Samples/0_Introduction/simpleCubemapTexture/CMakeLists.txt b/Samples/0_Introduction/simpleCubemapTexture/CMakeLists.txt
+index ea696b01..05618b0f 100644
+--- a/Samples/0_Introduction/simpleCubemapTexture/CMakeLists.txt
++++ b/Samples/0_Introduction/simpleCubemapTexture/CMakeLists.txt
+@@ -1,21 +1,11 @@
+ cmake_minimum_required(VERSION 3.20)
+ 
+-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/Modules")
+-
+ project(simpleCubemapTexture LANGUAGES C CXX CUDA)
+ 
+ find_package(CUDAToolkit REQUIRED)
+ 
+ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ 
+-set(CMAKE_CUDA_ARCHITECTURES 50 52 60 61 70 72 75 80 86 87 89 90 100 101 120)
+-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Wno-deprecated-gpu-targets")
+-if(ENABLE_CUDA_DEBUG)
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -G")        # enable cuda-gdb (may significantly affect performance on some targets)
+-else()
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -lineinfo") # add line information to all builds for debug tools (exclusive to -G option)
+-endif()
+-
+ # Include directories and libraries
+ include_directories(../../../Common)
+ 
+@@ -28,3 +18,5 @@ target_compile_options(simpleCubemapTexture PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-
+ target_compile_features(simpleCubemapTexture PRIVATE cxx_std_17 cuda_std_17)
+ 
+ set_target_properties(simpleCubemapTexture PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
++
++install(TARGETS simpleCubemapTexture RUNTIME DESTINATION ${CMAKE_INSTALL_CUDA_SAMPLES})
+diff --git a/Samples/0_Introduction/simpleLayeredTexture/CMakeLists.txt b/Samples/0_Introduction/simpleLayeredTexture/CMakeLists.txt
+index bae6dd8d..ab5f4765 100644
+--- a/Samples/0_Introduction/simpleLayeredTexture/CMakeLists.txt
++++ b/Samples/0_Introduction/simpleLayeredTexture/CMakeLists.txt
+@@ -1,21 +1,11 @@
+ cmake_minimum_required(VERSION 3.20)
+ 
+-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/Modules")
+-
+ project(simpleLayeredTexture LANGUAGES C CXX CUDA)
+ 
+ find_package(CUDAToolkit REQUIRED)
+ 
+ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ 
+-set(CMAKE_CUDA_ARCHITECTURES 50 52 60 61 70 72 75 80 86 87 89 90 100 101 120)
+-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Wno-deprecated-gpu-targets")
+-if(ENABLE_CUDA_DEBUG)
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -G")        # enable cuda-gdb (may significantly affect performance on some targets)
+-else()
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -lineinfo") # add line information to all builds for debug tools (exclusive to -G option)
+-endif()
+-
+ # Include directories and libraries
+ include_directories(../../../Common)
+ 
+@@ -28,3 +18,5 @@ target_compile_options(simpleLayeredTexture PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-
+ target_compile_features(simpleLayeredTexture PRIVATE cxx_std_17 cuda_std_17)
+ 
+ set_target_properties(simpleLayeredTexture PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
++
++install(TARGETS simpleLayeredTexture RUNTIME DESTINATION ${CMAKE_INSTALL_CUDA_SAMPLES})
+diff --git a/Samples/0_Introduction/simpleMultiCopy/CMakeLists.txt b/Samples/0_Introduction/simpleMultiCopy/CMakeLists.txt
+index f48c6e03..04354879 100644
+--- a/Samples/0_Introduction/simpleMultiCopy/CMakeLists.txt
++++ b/Samples/0_Introduction/simpleMultiCopy/CMakeLists.txt
+@@ -1,21 +1,11 @@
+ cmake_minimum_required(VERSION 3.20)
+ 
+-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/Modules")
+-
+ project(simpleMultiCopy LANGUAGES C CXX CUDA)
+ 
+ find_package(CUDAToolkit REQUIRED)
+ 
+ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ 
+-set(CMAKE_CUDA_ARCHITECTURES 50 52 60 61 70 72 75 80 86 87 89 90 100 101 120)
+-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Wno-deprecated-gpu-targets")
+-if(ENABLE_CUDA_DEBUG)
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -G")        # enable cuda-gdb (may significantly affect performance on some targets)
+-else()
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -lineinfo") # add line information to all builds for debug tools (exclusive to -G option)
+-endif()
+-
+ # Include directories and libraries
+ include_directories(../../../Common)
+ 
+@@ -28,3 +18,5 @@ target_compile_options(simpleMultiCopy PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--exte
+ target_compile_features(simpleMultiCopy PRIVATE cxx_std_17 cuda_std_17)
+ 
+ set_target_properties(simpleMultiCopy PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
++
++install(TARGETS simpleMultiCopy RUNTIME DESTINATION ${CMAKE_INSTALL_CUDA_SAMPLES})
+diff --git a/Samples/0_Introduction/simpleMultiGPU/CMakeLists.txt b/Samples/0_Introduction/simpleMultiGPU/CMakeLists.txt
+index ac73641c..1b3580c8 100644
+--- a/Samples/0_Introduction/simpleMultiGPU/CMakeLists.txt
++++ b/Samples/0_Introduction/simpleMultiGPU/CMakeLists.txt
+@@ -1,21 +1,11 @@
+ cmake_minimum_required(VERSION 3.20)
+ 
+-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/Modules")
+-
+ project(simpleMultiGPU LANGUAGES C CXX CUDA)
+ 
+ find_package(CUDAToolkit REQUIRED)
+ 
+ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ 
+-set(CMAKE_CUDA_ARCHITECTURES 50 52 60 61 70 72 75 80 86 87 89 90 100 101 120)
+-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Wno-deprecated-gpu-targets")
+-if(ENABLE_CUDA_DEBUG)
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -G")        # enable cuda-gdb (may significantly affect performance on some targets)
+-else()
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -lineinfo") # add line information to all builds for debug tools (exclusive to -G option)
+-endif()
+-
+ # Include directories and libraries
+ include_directories(../../../Common)
+ 
+@@ -28,3 +18,5 @@ target_compile_options(simpleMultiGPU PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--exten
+ target_compile_features(simpleMultiGPU PRIVATE cxx_std_17 cuda_std_17)
+ 
+ set_target_properties(simpleMultiGPU PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
++
++install(TARGETS simpleMultiGPU RUNTIME DESTINATION ${CMAKE_INSTALL_CUDA_SAMPLES})
+diff --git a/Samples/0_Introduction/simpleOccupancy/CMakeLists.txt b/Samples/0_Introduction/simpleOccupancy/CMakeLists.txt
+index 6859a157..c1ee5e79 100644
+--- a/Samples/0_Introduction/simpleOccupancy/CMakeLists.txt
++++ b/Samples/0_Introduction/simpleOccupancy/CMakeLists.txt
+@@ -1,21 +1,11 @@
+ cmake_minimum_required(VERSION 3.20)
+ 
+-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/Modules")
+-
+ project(simpleOccupancy LANGUAGES C CXX CUDA)
+ 
+ find_package(CUDAToolkit REQUIRED)
+ 
+ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ 
+-set(CMAKE_CUDA_ARCHITECTURES 50 52 60 61 70 72 75 80 86 87 89 90 100 101 120)
+-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Wno-deprecated-gpu-targets")
+-if(ENABLE_CUDA_DEBUG)
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -G")        # enable cuda-gdb (may significantly affect performance on some targets)
+-else()
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -lineinfo") # add line information to all builds for debug tools (exclusive to -G option)
+-endif()
+-
+ # Include directories and libraries
+ include_directories(../../../Common)
+ 
+@@ -28,3 +18,5 @@ target_compile_options(simpleOccupancy PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--exte
+ target_compile_features(simpleOccupancy PRIVATE cxx_std_17 cuda_std_17)
+ 
+ set_target_properties(simpleOccupancy PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
++
++install(TARGETS simpleOccupancy RUNTIME DESTINATION ${CMAKE_INSTALL_CUDA_SAMPLES})
+diff --git a/Samples/0_Introduction/simplePitchLinearTexture/CMakeLists.txt b/Samples/0_Introduction/simplePitchLinearTexture/CMakeLists.txt
+index 6d431f62..198dcb33 100644
+--- a/Samples/0_Introduction/simplePitchLinearTexture/CMakeLists.txt
++++ b/Samples/0_Introduction/simplePitchLinearTexture/CMakeLists.txt
+@@ -1,21 +1,11 @@
+ cmake_minimum_required(VERSION 3.20)
+ 
+-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/Modules")
+-
+ project(simplePitchLinearTexture LANGUAGES C CXX CUDA)
+ 
+ find_package(CUDAToolkit REQUIRED)
+ 
+ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ 
+-set(CMAKE_CUDA_ARCHITECTURES 50 52 60 61 70 72 75 80 86 87 89 90 100 101 120)
+-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Wno-deprecated-gpu-targets")
+-if(ENABLE_CUDA_DEBUG)
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -G")        # enable cuda-gdb (may significantly affect performance on some targets)
+-else()
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -lineinfo") # add line information to all builds for debug tools (exclusive to -G option)
+-endif()
+-
+ # Include directories and libraries
+ include_directories(../../../Common)
+ 
+@@ -28,3 +18,5 @@ target_compile_options(simplePitchLinearTexture PRIVATE $<$<COMPILE_LANGUAGE:CUD
+ target_compile_features(simplePitchLinearTexture PRIVATE cxx_std_17 cuda_std_17)
+ 
+ set_target_properties(simplePitchLinearTexture PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
++
++install(TARGETS simplePitchLinearTexture RUNTIME DESTINATION ${CMAKE_INSTALL_CUDA_SAMPLES})
+diff --git a/Samples/0_Introduction/simplePrintf/CMakeLists.txt b/Samples/0_Introduction/simplePrintf/CMakeLists.txt
+index f3ec60b8..7aeaa4d8 100644
+--- a/Samples/0_Introduction/simplePrintf/CMakeLists.txt
++++ b/Samples/0_Introduction/simplePrintf/CMakeLists.txt
+@@ -1,21 +1,11 @@
+ cmake_minimum_required(VERSION 3.20)
+ 
+-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/Modules")
+-
+ project(simplePrintf LANGUAGES C CXX CUDA)
+ 
+ find_package(CUDAToolkit REQUIRED)
+ 
+ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ 
+-set(CMAKE_CUDA_ARCHITECTURES 50 52 60 61 70 72 75 80 86 87 89 90 100 101 120)
+-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Wno-deprecated-gpu-targets")
+-if(ENABLE_CUDA_DEBUG)
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -G")        # enable cuda-gdb (may significantly affect performance on some targets)
+-else()
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -lineinfo") # add line information to all builds for debug tools (exclusive to -G option)
+-endif()
+-
+ # Include directories and libraries
+ include_directories(../../../Common)
+ 
+@@ -28,3 +18,5 @@ target_compile_options(simplePrintf PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--extende
+ target_compile_features(simplePrintf PRIVATE cxx_std_17 cuda_std_17)
+ 
+ set_target_properties(simplePrintf PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
++
++install(TARGETS simplePrintf RUNTIME DESTINATION ${CMAKE_INSTALL_CUDA_SAMPLES})
+diff --git a/Samples/0_Introduction/simpleStreams/CMakeLists.txt b/Samples/0_Introduction/simpleStreams/CMakeLists.txt
+index dce86206..410fac1f 100644
+--- a/Samples/0_Introduction/simpleStreams/CMakeLists.txt
++++ b/Samples/0_Introduction/simpleStreams/CMakeLists.txt
+@@ -1,21 +1,11 @@
+ cmake_minimum_required(VERSION 3.20)
+ 
+-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/Modules")
+-
+ project(simpleStreams LANGUAGES C CXX CUDA)
+ 
+ find_package(CUDAToolkit REQUIRED)
+ 
+ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ 
+-set(CMAKE_CUDA_ARCHITECTURES 50 52 60 61 70 72 75 80 86 87 89 90 100 101 120)
+-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Wno-deprecated-gpu-targets")
+-if(ENABLE_CUDA_DEBUG)
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -G")        # enable cuda-gdb (may significantly affect performance on some targets)
+-else()
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -lineinfo") # add line information to all builds for debug tools (exclusive to -G option)
+-endif()
+-
+ # Include directories and libraries
+ include_directories(../../../Common)
+ 
+@@ -28,3 +18,5 @@ target_compile_options(simpleStreams PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--extend
+ target_compile_features(simpleStreams PRIVATE cxx_std_17 cuda_std_17)
+ 
+ set_target_properties(simpleStreams PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
++
++install(TARGETS simpleStreams RUNTIME DESTINATION ${CMAKE_INSTALL_CUDA_SAMPLES})
+diff --git a/Samples/0_Introduction/simpleSurfaceWrite/CMakeLists.txt b/Samples/0_Introduction/simpleSurfaceWrite/CMakeLists.txt
+index 5c65251e..03e5ab3f 100644
+--- a/Samples/0_Introduction/simpleSurfaceWrite/CMakeLists.txt
++++ b/Samples/0_Introduction/simpleSurfaceWrite/CMakeLists.txt
+@@ -1,21 +1,11 @@
+ cmake_minimum_required(VERSION 3.20)
+ 
+-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/Modules")
+-
+ project(simpleSurfaceWrite LANGUAGES C CXX CUDA)
+ 
+ find_package(CUDAToolkit REQUIRED)
+ 
+ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ 
+-set(CMAKE_CUDA_ARCHITECTURES 50 52 60 61 70 72 75 80 86 87 89 90 100 101 120)
+-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Wno-deprecated-gpu-targets")
+-if(ENABLE_CUDA_DEBUG)
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -G")        # enable cuda-gdb (may significantly affect performance on some targets)
+-else()
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -lineinfo") # add line information to all builds for debug tools (exclusive to -G option)
+-endif()
+-
+ # Include directories and libraries
+ include_directories(../../../Common)
+ 
+@@ -35,3 +25,6 @@ add_custom_command(TARGET simpleSurfaceWrite POST_BUILD
+     ${CMAKE_CURRENT_SOURCE_DIR}/data
+     ${CMAKE_CURRENT_BINARY_DIR}
+ )
++
++install(TARGETS simpleSurfaceWrite RUNTIME DESTINATION ${CMAKE_INSTALL_CUDA_SAMPLES})
++install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ref_rotated.pgm ${CMAKE_CURRENT_BINARY_DIR}/teapot512.pgm DESTINATION ${CMAKE_INSTALL_CUDA_SAMPLES})
+diff --git a/Samples/0_Introduction/simpleTemplates/CMakeLists.txt b/Samples/0_Introduction/simpleTemplates/CMakeLists.txt
+index a821e7bb..c32b9eb2 100644
+--- a/Samples/0_Introduction/simpleTemplates/CMakeLists.txt
++++ b/Samples/0_Introduction/simpleTemplates/CMakeLists.txt
+@@ -1,21 +1,11 @@
+ cmake_minimum_required(VERSION 3.20)
+ 
+-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/Modules")
+-
+ project(simpleTemplates LANGUAGES C CXX CUDA)
+ 
+ find_package(CUDAToolkit REQUIRED)
+ 
+ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ 
+-set(CMAKE_CUDA_ARCHITECTURES 50 52 60 61 70 72 75 80 86 87 89 90 100 101 120)
+-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Wno-deprecated-gpu-targets")
+-if(ENABLE_CUDA_DEBUG)
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -G")        # enable cuda-gdb (may significantly affect performance on some targets)
+-else()
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -lineinfo") # add line information to all builds for debug tools (exclusive to -G option)
+-endif()
+-
+ # Include directories and libraries
+ include_directories(../../../Common)
+ 
+@@ -28,3 +18,5 @@ target_compile_options(simpleTemplates PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--exte
+ target_compile_features(simpleTemplates PRIVATE cxx_std_17 cuda_std_17)
+ 
+ set_target_properties(simpleTemplates PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
++
++install(TARGETS simpleTemplates RUNTIME DESTINATION ${CMAKE_INSTALL_CUDA_SAMPLES})
+diff --git a/Samples/0_Introduction/simpleTexture/CMakeLists.txt b/Samples/0_Introduction/simpleTexture/CMakeLists.txt
+index 688116ba..5de6bc07 100644
+--- a/Samples/0_Introduction/simpleTexture/CMakeLists.txt
++++ b/Samples/0_Introduction/simpleTexture/CMakeLists.txt
+@@ -1,21 +1,11 @@
+ cmake_minimum_required(VERSION 3.20)
+ 
+-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/Modules")
+-
+ project(simpleTexture LANGUAGES C CXX CUDA)
+ 
+ find_package(CUDAToolkit REQUIRED)
+ 
+ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ 
+-set(CMAKE_CUDA_ARCHITECTURES 50 52 60 61 70 72 75 80 86 87 89 90 100 101 120)
+-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Wno-deprecated-gpu-targets")
+-if(ENABLE_CUDA_DEBUG)
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -G")        # enable cuda-gdb (may significantly affect performance on some targets)
+-else()
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -lineinfo") # add line information to all builds for debug tools (exclusive to -G option)
+-endif()
+-
+ # Include directories and libraries
+ include_directories(../../../Common)
+ 
+@@ -42,3 +32,6 @@ add_custom_command(TARGET simpleTexture POST_BUILD
+     ${CMAKE_CURRENT_SOURCE_DIR}/data/ref_rotated.pgm
+     ${CMAKE_CURRENT_BINARY_DIR}/
+ )
++
++install(TARGETS simpleTexture RUNTIME DESTINATION ${CMAKE_INSTALL_CUDA_SAMPLES})
++install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ref_rotated.pgm ${CMAKE_CURRENT_BINARY_DIR}/teapot512.pgm DESTINATION ${CMAKE_INSTALL_CUDA_SAMPLES})
+diff --git a/Samples/0_Introduction/simpleVoteIntrinsics/CMakeLists.txt b/Samples/0_Introduction/simpleVoteIntrinsics/CMakeLists.txt
+index 1b151bcf..736eecb2 100644
+--- a/Samples/0_Introduction/simpleVoteIntrinsics/CMakeLists.txt
++++ b/Samples/0_Introduction/simpleVoteIntrinsics/CMakeLists.txt
+@@ -1,21 +1,11 @@
+ cmake_minimum_required(VERSION 3.20)
+ 
+-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/Modules")
+-
+ project(simpleVoteIntrinsics LANGUAGES C CXX CUDA)
+ 
+ find_package(CUDAToolkit REQUIRED)
+ 
+ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ 
+-set(CMAKE_CUDA_ARCHITECTURES 50 52 60 61 70 72 75 80 86 87 89 90 100 101 120)
+-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Wno-deprecated-gpu-targets")
+-if(ENABLE_CUDA_DEBUG)
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -G")        # enable cuda-gdb (may significantly affect performance on some targets)
+-else()
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -lineinfo") # add line information to all builds for debug tools (exclusive to -G option)
+-endif()
+-
+ # Include directories and libraries
+ include_directories(../../../Common)
+ 
+@@ -28,3 +18,5 @@ target_compile_options(simpleVoteIntrinsics PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-
+ target_compile_features(simpleVoteIntrinsics PRIVATE cxx_std_17 cuda_std_17)
+ 
+ set_target_properties(simpleVoteIntrinsics PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
++
++install(TARGETS simpleVoteIntrinsics RUNTIME DESTINATION ${CMAKE_INSTALL_CUDA_SAMPLES})
+diff --git a/Samples/0_Introduction/simpleZeroCopy/CMakeLists.txt b/Samples/0_Introduction/simpleZeroCopy/CMakeLists.txt
+index 1e93e05a..8bd429d7 100644
+--- a/Samples/0_Introduction/simpleZeroCopy/CMakeLists.txt
++++ b/Samples/0_Introduction/simpleZeroCopy/CMakeLists.txt
+@@ -1,21 +1,11 @@
+ cmake_minimum_required(VERSION 3.20)
+ 
+-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/Modules")
+-
+ project(simpleZeroCopy LANGUAGES C CXX CUDA)
+ 
+ find_package(CUDAToolkit REQUIRED)
+ 
+ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ 
+-set(CMAKE_CUDA_ARCHITECTURES 50 52 60 61 70 72 75 80 86 87 89 90 100 101 120)
+-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Wno-deprecated-gpu-targets")
+-if(ENABLE_CUDA_DEBUG)
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -G")        # enable cuda-gdb (may significantly affect performance on some targets)
+-else()
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -lineinfo") # add line information to all builds for debug tools (exclusive to -G option)
+-endif()
+-
+ # Include directories and libraries
+ include_directories(../../../Common)
+ 
+@@ -28,3 +18,5 @@ target_compile_options(simpleZeroCopy PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--exten
+ target_compile_features(simpleZeroCopy PRIVATE cxx_std_17 cuda_std_17)
+ 
+ set_target_properties(simpleZeroCopy PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
++
++install(TARGETS simpleZeroCopy RUNTIME DESTINATION ${CMAKE_INSTALL_CUDA_SAMPLES})
+diff --git a/Samples/0_Introduction/vectorAdd/CMakeLists.txt b/Samples/0_Introduction/vectorAdd/CMakeLists.txt
+index 4c6ef8cd..09879840 100644
+--- a/Samples/0_Introduction/vectorAdd/CMakeLists.txt
++++ b/Samples/0_Introduction/vectorAdd/CMakeLists.txt
+@@ -1,21 +1,11 @@
+ cmake_minimum_required(VERSION 3.20)
+ 
+-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/Modules")
+-
+ project(vectorAdd LANGUAGES C CXX CUDA)
+ 
+ find_package(CUDAToolkit REQUIRED)
+ 
+ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ 
+-set(CMAKE_CUDA_ARCHITECTURES 50 52 60 61 70 72 75 80 86 87 89 90 100 101 120)
+-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Wno-deprecated-gpu-targets")
+-if(ENABLE_CUDA_DEBUG)
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -G")  # enable cuda-gdb (may significantly affect performance on some targets)
+-else()
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -lineinfo") # add line information to all builds for debug tools (exclusive to -G option)
+-endif()
+-
+ # Include directories and libraries
+ include_directories(../../../Common)
+ 
+@@ -28,3 +18,5 @@ target_compile_options(vectorAdd PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--extended-l
+ target_compile_features(vectorAdd PRIVATE cxx_std_17 cuda_std_17)
+ 
+ set_target_properties(vectorAdd PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
++
++install(TARGETS vectorAdd RUNTIME DESTINATION ${CMAKE_INSTALL_CUDA_SAMPLES})
+diff --git a/Samples/1_Utilities/CMakeLists.txt b/Samples/1_Utilities/CMakeLists.txt
+index 1f3f481b..939d8efc 100644
+--- a/Samples/1_Utilities/CMakeLists.txt
++++ b/Samples/1_Utilities/CMakeLists.txt
+@@ -1,3 +1 @@
+ add_subdirectory(deviceQuery)
+-add_subdirectory(deviceQueryDrv)
+-add_subdirectory(topologyQuery)
+diff --git a/Samples/1_Utilities/deviceQuery/CMakeLists.txt b/Samples/1_Utilities/deviceQuery/CMakeLists.txt
+index 4b308e9c..0a9b7b1f 100644
+--- a/Samples/1_Utilities/deviceQuery/CMakeLists.txt
++++ b/Samples/1_Utilities/deviceQuery/CMakeLists.txt
+@@ -1,21 +1,11 @@
+ cmake_minimum_required(VERSION 3.20)
+ 
+-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/Modules")
+-
+ project(deviceQuery LANGUAGES C CXX CUDA)
+ 
+ find_package(CUDAToolkit REQUIRED)
+ 
+ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ 
+-set(CMAKE_CUDA_ARCHITECTURES 50 52 60 61 70 72 75 80 86 87 89 90 100 101 120)
+-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Wno-deprecated-gpu-targets")
+-if(ENABLE_CUDA_DEBUG)
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -G")        # enable cuda-gdb (may significantly affect performance on some targets)
+-else()
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -lineinfo") # add line information to all builds for debug tools (exclusive to -G option)
+-endif()
+-
+ # Include directories and libraries
+ include_directories(../../../Common)
+ 
+@@ -34,5 +24,7 @@ target_include_directories(deviceQuery PRIVATE
+ )
+ 
+ target_link_libraries(deviceQuery PUBLIC
+-    CUDA::cudart
++    cudart
+ )
++
++install(TARGETS deviceQuery RUNTIME DESTINATION ${CMAKE_INSTALL_CUDA_SAMPLES})
+diff --git a/Samples/6_Performance/CMakeLists.txt b/Samples/6_Performance/CMakeLists.txt
+index ac54e19a..abf7ce68 100644
+--- a/Samples/6_Performance/CMakeLists.txt
++++ b/Samples/6_Performance/CMakeLists.txt
+@@ -1,5 +1 @@
+-add_subdirectory(LargeKernelParameter)
+ add_subdirectory(UnifiedMemoryPerf)
+-add_subdirectory(alignedTypes)
+-add_subdirectory(cudaGraphsPerfScaling)
+-add_subdirectory(transpose)
+diff --git a/Samples/6_Performance/UnifiedMemoryPerf/CMakeLists.txt b/Samples/6_Performance/UnifiedMemoryPerf/CMakeLists.txt
+index 1cea77f3..f223c1fc 100644
+--- a/Samples/6_Performance/UnifiedMemoryPerf/CMakeLists.txt
++++ b/Samples/6_Performance/UnifiedMemoryPerf/CMakeLists.txt
+@@ -1,21 +1,11 @@
+ cmake_minimum_required(VERSION 3.20)
+ 
+-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/Modules")
+-
+ project(UnifiedMemoryPerf LANGUAGES C CXX CUDA)
+ 
+ find_package(CUDAToolkit REQUIRED)
+ 
+ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ 
+-set(CMAKE_CUDA_ARCHITECTURES 50 52 60 61 70 72 75 80 86 87 89 90 100 101 120)
+-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Wno-deprecated-gpu-targets")
+-if(ENABLE_CUDA_DEBUG)
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -G")        # enable cuda-gdb (may significantly affect performance on some targets)
+-else()
+-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -lineinfo") # add line information to all builds for debug tools (exclusive to -G option)
+-endif()
+-
+ # Include directories and libraries
+ include_directories(../../../Common)
+ 
+@@ -32,3 +22,5 @@ set_target_properties(UnifiedMemoryPerf PROPERTIES CUDA_SEPARABLE_COMPILATION ON
+ target_include_directories(UnifiedMemoryPerf PRIVATE
+     ${CUDAToolkit_INCLUDE_DIRS}
+ )
++
++install(TARGETS UnifiedMemoryPerf RUNTIME DESTINATION ${CMAKE_INSTALL_CUDA_SAMPLES})
+diff --git a/Samples/CMakeLists.txt b/Samples/CMakeLists.txt
+index 3f7a8f3c..f728b737 100644
+--- a/Samples/CMakeLists.txt
++++ b/Samples/CMakeLists.txt
+@@ -9,25 +9,6 @@ add_subdirectory(0_Introduction)
+ set(CMAKE_FOLDER "1_Utilities")
+ add_subdirectory(1_Utilities)
+ 
+-set(CMAKE_FOLDER "2_Concepts_and_Techniques")
+-add_subdirectory(2_Concepts_and_Techniques)
+-
+-set(CMAKE_FOLDER "3_CUDA_Features")
+-add_subdirectory(3_CUDA_Features)
+-
+-set(CMAKE_FOLDER "4_CUDA_Libraries")
+-add_subdirectory(4_CUDA_Libraries)
+-
+-set(CMAKE_FOLDER "5_Domain_Specific")
+-add_subdirectory(5_Domain_Specific)
+-
+ set(CMAKE_FOLDER "6_Performance")
+ add_subdirectory(6_Performance)
+ 
+-set(CMAKE_FOLDER "7_libNVVM")
+-add_subdirectory(7_libNVVM)
+-
+-if(BUILD_TEGRA)
+-    set(CMAKE_FOLDER "8_Platform_Specific/Tegra")
+-    add_subdirectory(8_Platform_Specific/Tegra)
+-endif()
+-- 
+2.34.1
+

--- a/recipes-devtools/cuda/cuda-samples-12-9_git.bb
+++ b/recipes-devtools/cuda/cuda-samples-12-9_git.bb
@@ -1,0 +1,32 @@
+DESCRIPTION = "CUDA sample programs"
+HOMEPAGE = "https://github.com/NVIDIA/cuda-samples"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=bb28b97ff25ae39de442985ec577dbd8"
+
+COMPATIBLE_MACHINE = "(tegra)"
+
+SRC_URI = " \
+    git://github.com/NVIDIA/cuda-samples.git;protocol=https;branch=master \
+    file://0001-Updates-for-OE-cross-builds.patch \
+"
+# v12.9 tag
+SRCREV = "cab7c66b4fcf35b09ea8fbc4c3c1a9272e92d997"
+
+CUDA_VERSION = "12.9"
+
+inherit cmake cuda
+
+DEPENDS:remove = "cuda-libraries cuda-compiler-native cuda-cudart-native"
+DEPENDS:append = " \
+    cuda-libraries-12-9 cuda-compiler-12-9-native cuda-cudart-12-9-native \
+    cuda-crt-12-9 cuda-profiler-api-12-9 libcublas-12-9 \
+"
+
+PV = "12.9"
+
+CUDA_SAMPLES_INSTALL_PATH = "${bindir}/cuda-samples-12-9"
+EXTRA_OECMAKE:append = " -DCMAKE_INSTALL_CUDA_SAMPLES=${CUDA_SAMPLES_INSTALL_PATH}"
+
+PACKAGE_ARCH = "${TEGRA_PKGARCH}"
+
+INSANE_SKIP:${PN} += "buildpaths"

--- a/recipes-devtools/cuda/cuda-sanitizer-12-9_12.9.79-1.bb
+++ b/recipes-devtools/cuda/cuda-sanitizer-12-9_12.9.79-1.bb
@@ -1,0 +1,30 @@
+CUDA_PKG = "cuda-sanitizer"
+L4T_DEB_GROUP = "cuda-sanitizer-api-12-9"
+
+require cuda-shared-binaries-12.9.inc
+
+MAINSUM = "cc43cb7c452e325f4b71a980f12881da87f4d0534084780a9aeeb80f75f180e2"
+MAINSUM:x86-64 = "3b2fdf2c3caf82cddc4c4c0f93b3877a5671de04ab7778f9e7d517e497a05218"
+
+do_compile:append() {
+    rm -rf ${S}/usr/local/cuda-${CUDA_VERSION}/compute-sanitizer/x86
+}
+
+FILES:${PN} += " \
+    ${prefix}/local/cuda-${CUDA_VERSION}/compute-sanitizer/TreeLauncherSubreaper \
+    ${prefix}/local/cuda-${CUDA_VERSION}/compute-sanitizer/compute-sanitizer \
+    ${prefix}/local/cuda-${CUDA_VERSION}/compute-sanitizer/TreeLauncherTargetLdPreloadHelper \
+"
+
+FILES:${PN}-dev += " \
+    ${prefix}/local/cuda-${CUDA_VERSION}/compute-sanitizer/*${SOLIBSDEV} \
+    ${prefix}/local/cuda-${CUDA_VERSION}/compute-sanitizer/include \
+"
+
+FILES:${PN}-doc += " \
+    ${prefix}/local/cuda-${CUDA_VERSION}/compute-sanitizer/docs \
+"
+
+RDEPENDS:${PN} += "bash"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/cuda/cuda-shared-binaries-12.9.inc
+++ b/recipes-devtools/cuda/cuda-shared-binaries-12.9.inc
@@ -1,0 +1,109 @@
+CUDA_PKG ?= "${BPN} ${BPN}-dev"
+
+require cuda-binaries-common-defs.inc
+CUDA_VERSION = "12.9"
+
+L4T_DEB_GROUP ?= "${BPN}"
+CUDA_DEB_FEED_BASE = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204"
+L4T_DEB_FEED_BASE = "${CUDA_DEB_FEED_BASE}/arm64"
+L4T_DEB_FEED_BASE:x86-64 = "${CUDA_DEB_FEED_BASE}/x86_64"
+L4T_DEB_FEED_SKIP_POOL_APPEND = "1"
+CUDA_LICENSE_PKG ?= "cuda-documentation-${CUDA_VERSION_DASHED}_12.9.88-1_${CUDA_DEB_PKGARCH}.deb;name=lic;subdir=${BP}"
+SRC_COMMON_DEBS = "${@' '.join(['%s-${CUDA_VERSION_DASHED}_${PV}_${CUDA_DEB_PKGARCH}.deb;name=%s;subdir=${BP}' \
+                                % (pkg, 'dev' if pkg.endswith('-dev') else 'main') for pkg in d.getVar('CUDA_PKG').split()])} \
+	           ${CUDA_LICENSE_PKG}"
+
+
+SRC_URI[main.sha256sum] = "${MAINSUM}"
+SRC_URI[dev.sha256sum] = "${DEVSUM}"
+LICSUM ?= "528dd7ac7d82e372e8125e7ef2614ec36643a3cd9bb8202888d4efde6e7d9abb"
+LICSUM:x86-64 ?= "b421792d35a9b3321dfcfeef797eb29b0ae77e06afa8532c5f64f2ad8eb94df7"
+SRC_URI[lic.sha256sum] = "${LICSUM}"
+L4T_DEB_GROUP[lic] = "cuda-documentation"
+
+CUDA_DL_CLASS = "l4t_deb_pkgfeed"
+
+inherit ${CUDA_DL_CLASS}
+
+DESCRIPTION = "CUDA package ${PN}"
+LICENSE = "Proprietary"
+LIC_FILES_CHKSUM ?= "file://usr/local/cuda-${CUDA_VERSION}/EULA.txt;md5=efcee438abe65815bfda243bdc613b7e"
+
+DEPENDS ?= "cuda-cudart-12-9"
+CUDA_VERSION_DASHED = "${@d.getVar('CUDA_VERSION').replace('.','-')}"
+
+CUDA_PKGNAMES ?= "${@' '.join(['%s-${CUDA_VERSION_DASHED}_${PV}_${CUDA_DEB_PKGARCH}.deb' % pkg for pkg in d.getVar('CUDA_PKG').split()])}"
+
+CUDA_INSTALL_ARCH ?= "${HOST_ARCH}"
+
+do_compile() {
+    rm -f ${B}/usr/local/cuda-${CUDA_VERSION}/lib64
+    [ -L ${B}/usr/local/cuda-${CUDA_VERSION}/include ] && rm ${B}/usr/local/cuda-${CUDA_VERSION}/include
+    if [ -d ${B}/usr/local/cuda-${CUDA_VERSION}/targets/${CUDA_INSTALL_ARCH}-${HOST_OS} ]; then
+        oldwd="$PWD"
+	cd ${B}/usr/local/cuda-${CUDA_VERSION}/targets/${CUDA_INSTALL_ARCH}-${HOST_OS}
+	for d in *; do
+	    [ -d $d ] || continue
+	    if [ -d ${B}/usr/local/cuda-${CUDA_VERSION}/$d ]; then
+	        mv $d/* ${B}/usr/local/cuda-${CUDA_VERSION}/$d/
+		rmdir $d
+	    else
+	        mv $d ${B}/usr/local/cuda-${CUDA_VERSION}/
+	    fi
+	done
+	cd "$oldwd"
+	rmdir ${B}/usr/local/cuda-${CUDA_VERSION}/targets/${CUDA_INSTALL_ARCH}-${HOST_OS}
+	rmdir ${B}/usr/local/cuda-${CUDA_VERSION}/targets
+    fi
+    if [ -d ${B}/usr/lib/pkgconfig ]; then
+        for f in ${B}/usr/lib/pkgconfig/*; do
+            sed -i -r -e's,^(libdir=.*/)lib[^/]*$,\1${baselib},' \
+		-e's,/targets/${CUDA_INSTALL_ARCH}-${HOST_OS},,g' \
+                -e's,^(libdir=.*/)lib[^/]*(/.*)$,\1${baselib}\2,' \
+                -e's!^(Libs:.*)!\1 -Wl,-rpath=$!' $f
+            sed -i -re's,^(Libs:.*),\1{libdir},' $f
+	done
+    fi
+    if [ "${baselib}" != "lib" ]; then
+        if [ -d ${B}/usr/lib ]; then
+            mv ${B}/usr/lib ${B}/usr/${baselib}
+	fi
+	if [ -d ${B}/usr/local/cuda-${CUDA_VERSION}/lib ]; then
+            mv ${B}/usr/local/cuda-${CUDA_VERSION}/lib ${B}/usr/local/cuda-${CUDA_VERSION}/${baselib}
+	fi
+    fi
+    rm -rf ${B}/usr/share/doc
+    if [ -d "${B}/usr/share" ]; then
+        [ -n "$(ls ${B}/usr/share)" ] || rmdir ${B}/usr/share
+    fi
+}
+
+do_install() {
+    install -d ${D}${prefix}
+    cp -R --preserve=mode,timestamps ${B}/usr/* ${D}${prefix}/
+    rm -rf ${D}${prefix}/local/cuda-${CUDA_VERSION}/doc ${D}${prefix}/local/cuda-${CUDA_VERSION}/tools
+    rm -f ${D}${prefix}/local/cuda-${CUDA_VERSION}/LICENSE ${D}${prefix}/local/cuda-${CUDA_VERSION}/README ${D}${prefix}/local/cuda-${CUDA_VERSION}/version.txt
+    rm -f ${D}${prefix}/local/cuda-${CUDA_VERSION}/EULA.txt
+    rm -f ${D}${prefix}/local/cuda-${CUDA_VERSION}/DOCS
+}
+
+PACKAGES =+ "${PN}-stubs"
+FILES:${PN} += "${prefix}/local/cuda-${CUDA_VERSION}/${baselib}/*${SOLIBS} ${prefix}/local/cuda-${CUDA_VERSION}/bin"
+FILES:${PN}-stubs = "${prefix}/local/cuda-${CUDA_VERSION}/${baselib}/stubs"
+FILES:${PN}-dev += "${prefix}/local/cuda-${CUDA_VERSION}/extras ${prefix}/local/cuda-${CUDA_VERSION}/include \
+                    ${prefix}/local/cuda-${CUDA_VERSION}/src \
+                    ${prefix}/local/cuda-${CUDA_VERSION}/${baselib}/*${SOLIBSDEV}"
+FILES:${PN}-staticdev += "${prefix}/local/cuda-${CUDA_VERSION}/${baselib}/*.a"
+RDEPENDS:${PN}-dev = "${PN}-stubs"
+ALLOW_EMPTY:${PN}-stubs = "1"
+EXCLUDE_PACKAGES_FROM_SHLIBS = "${PN}-stubs"
+INSANE_SKIP:${PN} = "ldflags libdir"
+INSANE_SKIP:${PN}-dev = "ldflags libdir dev-elf"
+INSANE_SKIP:${PN}-stubs = "ldflags libdir dev-so"
+
+sysroot_stage_dirs:append() {
+    sysroot_stage_dir $from${prefix}/local/cuda-${CUDA_VERSION} $to${prefix}/local/cuda-${CUDA_VERSION}
+}
+
+COMPATIBLE_MACHINE:class-target = "(tegra)"
+PACKAGE_ARCH:class-target = "${TEGRA_PKGARCH}"

--- a/recipes-devtools/cuda/cuda-toolkit-12-9_12.9.1-1.bb
+++ b/recipes-devtools/cuda/cuda-toolkit-12-9_12.9.1-1.bb
@@ -1,0 +1,25 @@
+DESCRIPTION = "Dummy recipe for bringing in CUDA tools and libraries"
+LICENSE = "MIT"
+
+DEPENDS = " \
+    cuda-command-line-tools-12-9 \
+    cuda-compiler-12-9 \
+    cuda-libraries-12-9 \
+    cuda-nvml-12-9 \
+"
+
+do_fetch[noexec] = "1"
+do_unpack[noexec] = "1"
+do_patch[noexec] = "1"
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
+do_install[noexec] = "1"
+
+COMPATIBLE_MACHINE:class-target = "tegra"
+PACKAGE_ARCH:class-target = "${TEGRA_PKGARCH}"
+
+PACKAGES = "${PN} ${PN}-dev"
+ALLOW_EMPTY:${PN} = "1"
+RDEPENDS:${PN} = "cuda-command-line-tools-12-9 cuda-compiler-12-9 cuda-libraries-12-9-dev cuda-nvml-12-9-dev"
+INSANE_SKIP:${PN} = "dev-deps"
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/cuda/libcublas-12-9_12.9.1.4-1.bb
+++ b/recipes-devtools/cuda/libcublas-12-9_12.9.1.4-1.bb
@@ -1,0 +1,13 @@
+CUDA_PKG = "libcublas libcublas-dev"
+
+require cuda-shared-binaries-12.9.inc
+
+MAINSUM = "d42a77917a867c7fadb96cbe67f5469e75712912ff35019319e84fc42aa0591b"
+MAINSUM:x86-64 = "e20d6c5e1e8b05c1b7ca25bffa0b60eac213a19aa4780adbdc0ec254e8071f9f"
+DEVSUM = "3c4de4aead5eb45999d513e7ed45436f386001c3094113ea6b100a89343c074c"
+DEVSUM:x86-64 = "7f09cc1eccfa2da100f4cfdafcaa5e978ef0972ab1840c2436b68ee83e7069b5"
+
+EXCLUDE_PACKAGES_FROM_SHLIBS = ""
+PRIVATE_LIBS:${PN}-stubs = "libcublas.so.12 libcublasLt.so.12"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/cuda/libcudla-12-9_12.9.19-1.bb
+++ b/recipes-devtools/cuda/libcudla-12-9_12.9.19-1.bb
@@ -1,0 +1,8 @@
+CUDA_PKG = "libcudla libcudla-dev"
+
+require cuda-shared-binaries-12.9.inc
+
+MAINSUM = "b45b97605b9c9862c82b2d18ac88e1d5202511370f5af5052d8169705a70ad95"
+DEVSUM = "6f90e9fcaa3738d942627fae26156f2c4cebad2f1b6a54c92cb3137e52b56450"
+
+RDEPENDS:${PN} = "tegra-libraries-core tegra-libraries-cuda"

--- a/recipes-devtools/cuda/libcufft-12-9_11.4.1.4-1.bb
+++ b/recipes-devtools/cuda/libcufft-12-9_11.4.1.4-1.bb
@@ -1,0 +1,10 @@
+CUDA_PKG = "libcufft libcufft-dev"
+
+require cuda-shared-binaries-12.9.inc
+
+MAINSUM = "69904d1b053ab533d06af4ed422780fe416e89a55c1dd5705f941391149ae269"
+MAINSUM:x86-64 = "8687decb37f34fe0fb4c07a97f56a3b6d75a8e0b12b09aebbcfc671325a82c37"
+DEVSUM = "586970e61493ce4ca26df3e49b7e8c90159b9ab56bb7670813f8646032e2cf04"
+DEVSUM:x86-64 = "9c6a1819a808a9fabb8dfaf7ebb4ce2f599b3bae5fd63c09dcf24508efc0b462"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/cuda/libcufile-12-9_1.14.1.1-1.bb
+++ b/recipes-devtools/cuda/libcufile-12-9_1.14.1.1-1.bb
@@ -1,0 +1,19 @@
+CUDA_PKG = "libcufile libcufile-dev"
+
+require cuda-shared-binaries-12.9.inc
+
+MAINSUM = "e09b9a56a582001a68d6ac3cbdd4228ee8ef5fcc9e11c02aa5fae8613389fb0e"
+MAINSUM:x86-64 = "f7d7ce3cdf35b7a0cab2ff7925f9f918f72f579365731c98f5dffd4e607c0f10"
+DEVSUM = "6bbccb6751b6273414d2fb7f9de5a44d2c0639f0179ed366d0b9190bf44cb268"
+DEVSUM:x86-64 = "40f9ca844eaea14d5c67c15ddaf31330df2e7d828dfe513c96eace63d708626d"
+
+# XXX -
+#  The RDMA support has runtime requirements on RDMA/Infiband
+#  libraries that we don't have recipes for in OE-Core or here.
+# - XXX
+do_install:append() {
+    rm -rf ${D}${prefix}/local/cuda-${CUDA_VERSION}/gds
+    rm -f ${D}${prefix}/local/cuda-${CUDA_VERSION}/lib/libcufile_rdma*
+}
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/cuda/libcurand-12-9_10.3.10.19-1.bb
+++ b/recipes-devtools/cuda/libcurand-12-9_10.3.10.19-1.bb
@@ -1,0 +1,10 @@
+CUDA_PKG = "libcurand libcurand-dev"
+
+require cuda-shared-binaries-12.9.inc
+
+MAINSUM = "d1d2ea91ace274484a7712afc2c55950d8c5e1f423ae66fa9ea346fe55307d65"
+MAINSUM:x86-64 = "745bdfe7fc3651202451fe1f11b5be647d00a4bbd31ba4058720cec39967e6f0"
+DEVSUM = "da7d85da4a2f1024721187a522771bf805bdd59a8f2e1ea11ff8762122d2be4f"
+DEVSUM:x86-64 = "ffa9e0661c697f5d0a890bdf8d80783e0bf96d2adb2c5a564e9d8b27d095546f"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/cuda/libcusolver-12-9_11.7.5.82-1.bb
+++ b/recipes-devtools/cuda/libcusolver-12-9_11.7.5.82-1.bb
@@ -1,0 +1,11 @@
+CUDA_PKG = "libcusolver libcusolver-dev"
+
+require cuda-shared-binaries-12.9.inc
+
+MAINSUM = "1bc1c78880cec6bbf30e1ee912bbaeef4b18fee0a9c330f57a5354cafc9fc54f"
+MAINSUM:x86-64 = "75f819430e2fd1bbed16329993c0f270d8c970f65f0c9c15d31ed8b6c2b5ae14"
+DEVSUM = "c4091a6a2d3696ab86b54489107da108f88ec7aa86e146879e5c5855f11a0da7"
+DEVSUM:x86-64 = "bc85bdce2788f135b6f751fc97a50bcc0958817ba649fc66dbe8d24fed6dbf49"
+
+RDEPENDS:${PN} = "libcublas-12-9 libcusparse-12-9 libnvjitlink-12-9"
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/cuda/libcusparse-12-9_12.5.10.65-1.bb
+++ b/recipes-devtools/cuda/libcusparse-12-9_12.5.10.65-1.bb
@@ -1,0 +1,12 @@
+CUDA_PKG = "libcusparse libcusparse-dev"
+
+require cuda-shared-binaries-12.9.inc
+
+MAINSUM = "99d3bfa60b34a1f4eefe2d3b04e9f8002bb917d81e3ffafc1a14a5c6c8b5f3e6"
+MAINSUM:x86-64 = "7cb624b1a5d572f9085fdb468b099e4933758684d413d2326fd2cbb3d3419b60"
+DEVSUM = "6f5bf8b10ca19f8a3ab09da46e241290a0f7a043b27f7c1b171ed5b1cc6cc445"
+DEVSUM:x86-64 = "0e206426ca80de4f7fe17491d1f57ace661a42192d5345ee95beafa6d429d96b"
+
+RDEPENDS:${PN} = "libnvjitlink-12-9"
+RDEPENDS:${PN}-stubs = "libnvjitlink-12-9"
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/cuda/libnpp-12-9_12.4.1.87-1.bb
+++ b/recipes-devtools/cuda/libnpp-12-9_12.4.1.87-1.bb
@@ -1,0 +1,10 @@
+CUDA_PKG = "libnpp libnpp-dev"
+
+require cuda-shared-binaries-12.9.inc
+
+MAINSUM = "75e67d423cc6705926e18dad9acd273a7ef2304ae4f842117a532a916ffae6b1"
+MAINSUM:x86-64 = "bc613bc58b18e5486e623c60f84971c3d4f5487b77240663f8c0d39c77791eb3"
+DEVSUM = "96d5cd851e335087ca8a276d6d675b9350374af1bc084911b50f3be754bdddf3"
+DEVSUM:x86-64 = "a10f2393d7883236bdabc30dfde0bafe162660f73a93ad0482d8a6f645bfc248"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/cuda/libnvfatbin-12-9_12.9.82-1.bb
+++ b/recipes-devtools/cuda/libnvfatbin-12-9_12.9.82-1.bb
@@ -1,0 +1,10 @@
+CUDA_PKG = "libnvfatbin libnvfatbin-dev"
+
+require cuda-shared-binaries-12.9.inc
+
+MAINSUM = "d0b2b1d484c726169b5a32f2888d08edd52c1ff5fd2e3e6ee2add1eee0c5f4f9"
+MAINSUM:x86-64 = "29e658354f3650e2cbfc41d7b7865986b46600347d7cb713bf637dc7f20f21a0"
+DEVSUM = "9667d2de82401b845312abce4fd00c5f6f8e5438ea39ed7187f07062dd003b9d"
+DEVSUM:x86-64 = "56063bdfa5279c0d3749d24d27aa479052f2f643557cc0f62720779e12655e2d"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/cuda/libnvjitlink-12-9_12.9.86-1.bb
+++ b/recipes-devtools/cuda/libnvjitlink-12-9_12.9.86-1.bb
@@ -1,0 +1,16 @@
+CUDA_PKG = "libnvjitlink libnvjitlink-dev"
+
+require cuda-shared-binaries-12.9.inc
+
+MAINSUM = "4e2efd9baeae6b830ace3da3cd96dd9294b6ccfa54e3007b687945e1c4e7bf44"
+MAINSUM:x86-64 = "e5db2bbbb1cc571360686ba6ce6898fd15da3db438592777a6472eb7dfe620b4"
+DEVSUM = "90f66ab235ba38c572f18ae2ee734e3e801826926a4e62cdcf639c882e298688"
+DEVSUM:x86-64 = "68bf8c5fd0c3734ae866e4b5a622db9eb9d3f71fda39d34b496e53384a2304f5"
+
+do_compile:prepend() {
+	rm -rf ${B}/usr/local/cuda-${CUDA_VERSION}/res
+}
+
+FILES:${PN} += "${prefix}/local/cuda-${CUDA_VERSION}/res"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/cuda/libnvjpeg-12-9_12.4.0.76-1.bb
+++ b/recipes-devtools/cuda/libnvjpeg-12-9_12.4.0.76-1.bb
@@ -1,0 +1,10 @@
+CUDA_PKG = "libnvjpeg libnvjpeg-dev"
+
+require cuda-shared-binaries-12.9.inc
+
+MAINSUM = "a8aad2e617e7c81c2575e82b4f148fa0400798d1244eb30578aa75764acb12b3"
+MAINSUM:x86-64 = "c965b608452aca8b8a273e6de110257b042eb9bc51fa0bd0dbf4781bbe48530a"
+DEVSUM = "677b245508b03d9b52f4446bce73590abb8440976a382566ba96e6f1f8a87325"
+DEVSUM:x86-64 = "fe73fba73d707ff40d91e85899e8397a0dfe7d9c0b5b262da55969c109a68809"
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
* Tests were done on `jetson-agx-orin-devkit-industrial` with image `demo-image-base`

* Add the following line in your `conf/local.conf`
```
CORE_IMAGE_BASE_INSTALL:append = " cuda-samples-12-9 cuda-compat-12-9"
```

* Running new `cuda` sample application

```
root@jetson-agx-orin-devkit-industrial:~# LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda-12.9/compat /usr/bin/cuda-samples-12-9/deviceQuery 
/usr/bin/cuda-samples-12-9/deviceQuery Starting...

 CUDA Device Query (Runtime API) version (CUDART static linking)

Detected 1 CUDA Capable device(s)

Device 0: "Orin"
  CUDA Driver Version / Runtime Version          12.9 / 12.9
  CUDA Capability Major/Minor version number:    8.7
  Total amount of global memory:                 54793 MBytes (57454317568 bytes)
  (008) Multiprocessors, (128) CUDA Cores/MP:    1024 CUDA Cores
  GPU Max Clock rate:                            1185 MHz (1.18 GHz)
  Memory Clock rate:                             612 Mhz
  Memory Bus Width:                              256-bit
  L2 Cache Size:                                 4194304 bytes
  Maximum Texture Dimension Size (x,y,z)         1D=(131072), 2D=(131072, 65536), 3D=(16384, 16384, 16384)
  Maximum Layered 1D Texture Size, (num) layers  1D=(32768), 2048 layers
  Maximum Layered 2D Texture Size, (num) layers  2D=(32768, 32768), 2048 layers
  Total amount of constant memory:               65536 bytes
  Total amount of shared memory per block:       49152 bytes
  Total shared memory per multiprocessor:        167936 bytes
  Total number of registers available per block: 65536
  Warp size:                                     32
  Maximum number of threads per multiprocessor:  1536
  Maximum number of threads per block:           1024
  Max dimension size of a thread block (x,y,z): (1024, 1024, 64)
  Max dimension size of a grid size    (x,y,z): (2147483647, 65535, 65535)
  Maximum memory pitch:                          2147483647 bytes
  Texture alignment:                             512 bytes
  Concurrent copy and kernel execution:          Yes with 2 copy engine(s)
  Run time limit on kernels:                     No
  Integrated GPU sharing Host Memory:            Yes
  Support host page-locked memory mapping:       Yes
  Alignment requirement for Surfaces:            Yes
  Device has ECC support:                        Disabled
  Device supports Unified Addressing (UVA):      Yes
  Device supports Managed Memory:                Yes
  Device supports Compute Preemption:            Yes
  Supports Cooperative Kernel Launch:            Yes
  Supports MultiDevice Co-op Kernel Launch:      Yes
  Device PCI Domain ID / Bus ID / location ID:   0 / 0 / 0
  Compute Mode:
     < Default (multiple host threads can use ::cudaSetDevice() with device simultaneously) >

deviceQuery, CUDA Driver = CUDART, CUDA Driver Version = 12.9, CUDA Runtime Version = 12.9, NumDevs = 1
Result = PASS
root@jetson-agx-orin-devkit-industrial:~#
```

* Running the default `cuda` sample application

```
root@jetson-agx-orin-devkit-industrial:~# /usr/bin/cuda-samples/deviceQuery 
/usr/bin/cuda-samples/deviceQuery Starting...

 CUDA Device Query (Runtime API) version (CUDART static linking)

Detected 1 CUDA Capable device(s)

Device 0: "Orin"
  CUDA Driver Version / Runtime Version          12.6 / 12.6
  CUDA Capability Major/Minor version number:    8.7
  Total amount of global memory:                 54793 MBytes (57454317568 bytes)
  (008) Multiprocessors, (128) CUDA Cores/MP:    1024 CUDA Cores
  GPU Max Clock rate:                            1185 MHz (1.18 GHz)
  Memory Clock rate:                             612 Mhz
  Memory Bus Width:                              256-bit
  L2 Cache Size:                                 4194304 bytes
  Maximum Texture Dimension Size (x,y,z)         1D=(131072), 2D=(131072, 65536), 3D=(16384, 16384, 16384)
  Maximum Layered 1D Texture Size, (num) layers  1D=(32768), 2048 layers
  Maximum Layered 2D Texture Size, (num) layers  2D=(32768, 32768), 2048 layers
  Total amount of constant memory:               65536 bytes
  Total amount of shared memory per block:       49152 bytes
  Total shared memory per multiprocessor:        167936 bytes
  Total number of registers available per block: 65536
  Warp size:                                     32
  Maximum number of threads per multiprocessor:  1536
  Maximum number of threads per block:           1024
  Max dimension size of a thread block (x,y,z): (1024, 1024, 64)
  Max dimension size of a grid size    (x,y,z): (2147483647, 65535, 65535)
  Maximum memory pitch:                          2147483647 bytes
  Texture alignment:                             512 bytes
  Concurrent copy and kernel execution:          Yes with 2 copy engine(s)
  Run time limit on kernels:                     No
  Integrated GPU sharing Host Memory:            Yes
  Support host page-locked memory mapping:       Yes
  Alignment requirement for Surfaces:            Yes
  Device has ECC support:                        Disabled
  Device supports Unified Addressing (UVA):      Yes
  Device supports Managed Memory:                Yes
  Device supports Compute Preemption:            Yes
  Supports Cooperative Kernel Launch:            Yes
  Supports MultiDevice Co-op Kernel Launch:      Yes
  Device PCI Domain ID / Bus ID / location ID:   0 / 0 / 0
  Compute Mode:
     < Default (multiple host threads can use ::cudaSetDevice() with device simultaneously) >

deviceQuery, CUDA Driver = CUDART, CUDA Driver Version = 12.6, CUDA Runtime Version = 12.6, NumDevs = 1
Result = PASS
root@jetson-agx-orin-devkit-industrial:~# 
```
