### PR TITLE
tegra-configs: fix path to nvpower.sh

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-configs/0001-Correct-path-to-nvpower.sh.patch
+++ b/recipes-bsp/tegra-binaries/tegra-configs/0001-Correct-path-to-nvpower.sh.patch
@@ -1,0 +1,50 @@
+From 1cb440c49e143896cea839d28ab6686977773102 Mon Sep 17 00:00:00 2001
+From: Peter Bergin <peter@berginkonsult.se>
+Date: Mon, 15 Dec 2025 12:35:47 +0100
+Subject: [PATCH] Correct path to nvpower.sh
+
+In the recipe for tegra-nvpower the script 'nvpower.sh' is installed
+in the path '/usr/libexec'. Jetson Linux put that script in
+'/etc/systemd'. The udev rules reference that script and needs
+to be updated for meta-tegra to find 'nvpower.sh'.
+
+Upstream-Status: Inappropriate [OE specific]
+
+Signed-off-by: Peter Bergin <peter@berginkonsult.se>
+Signed-off-by: Peter Bergin <peter.bergin@1x.tech>
+---
+ etc/udev/rules.d/99-tegra-devices.rules | 22 +++++++++++-----------
+ 1 file changed, 11 insertions(+), 11 deletions(-)
+
+diff --git a/etc/udev/rules.d/99-tegra-devices.rules b/etc/udev/rules.d/99-tegra-devices.rules
+index ecdfa14..1a508d3 100644
+--- a/etc/udev/rules.d/99-tegra-devices.rules
++++ b/etc/udev/rules.d/99-tegra-devices.rules
+@@ -86,16 +86,16 @@ KERNEL=="capture-*" OWNER="root" GROUP="video" MODE="0660"
+ KERNEL=="cdi_tsc" OWNER="root" GROUP="video" MODE="0660"
+ 
+ # Power policies
+-SUBSYSTEM=="pci", DEVPATH=="/devices/platform/bus@0/d0b0000000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0", ACTION=="bind", RUN+="/bin/bash /etc/systemd/nvpower.sh --gpu"
+-SUBSYSTEM=="platform", DEVPATH=="/devices/platform/bus@0/17000000.gpu", ACTION=="bind|change", RUN+="/bin/bash /etc/systemd/nvpower.sh --gpu"
+-SUBSYSTEM=="platform", DEVPATH=="/devices/platform/bus@0/*/8188050000.vic", ACTION=="bind|change", RUN+="/bin/bash /etc/systemd/nvpower.sh --vic"
+-SUBSYSTEM=="platform", DEVPATH=="/devices/platform/bus@0/*/15340000.vic", ACTION=="bind|change", RUN+="/bin/bash /etc/systemd/nvpower.sh --vic"
+-SUBSYSTEM=="platform", DEVPATH=="/devices/platform/bus@0/*/15480000.nvdec", ACTION=="bind|change", RUN+="/bin/bash /etc/systemd/nvpower.sh --nvdec"
+-SUBSYSTEM=="platform", DEVPATH=="/devices/platform/bus@0/*/154c0000.nvenc", ACTION=="bind|change", RUN+="/bin/bash /etc/systemd/nvpower.sh --nvenc"
+-SUBSYSTEM=="hwmon", DEVPATH=="/devices/platform/bus@0/c600000.i2c/i2c-2/2-0044/hwmon/*", ACTION=="bind|change", RUN+="/bin/bash /etc/systemd/nvpower.sh --ina238"
+-SUBSYSTEM=="net", KERNEL=="mgbe0_0", RUN+="/bin/bash /etc/systemd/nvpower.sh --mgbe"
+-SUBSYSTEM=="net", KERNEL=="mgbe1_0", RUN+="/bin/bash /etc/systemd/nvpower.sh --mgbe"
+-SUBSYSTEM=="net", KERNEL=="mgbe2_0", RUN+="/bin/bash /etc/systemd/nvpower.sh --mgbe"
+-SUBSYSTEM=="net", KERNEL=="mgbe3_0", RUN+="/bin/bash /etc/systemd/nvpower.sh --mgbe"
++SUBSYSTEM=="pci", DEVPATH=="/devices/platform/bus@0/d0b0000000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0", ACTION=="bind", RUN+="/bin/bash /usr/libexec/nvpower.sh --gpu"
++SUBSYSTEM=="platform", DEVPATH=="/devices/platform/bus@0/17000000.gpu", ACTION=="bind|change", RUN+="/bin/bash /usr/libexec/nvpower.sh --gpu"
++SUBSYSTEM=="platform", DEVPATH=="/devices/platform/bus@0/*/8188050000.vic", ACTION=="bind|change", RUN+="/bin/bash /usr/libexec/nvpower.sh --vic"
++SUBSYSTEM=="platform", DEVPATH=="/devices/platform/bus@0/*/15340000.vic", ACTION=="bind|change", RUN+="/bin/bash /usr/libexec/nvpower.sh --vic"
++SUBSYSTEM=="platform", DEVPATH=="/devices/platform/bus@0/*/15480000.nvdec", ACTION=="bind|change", RUN+="/bin/bash /usr/libexec/nvpower.sh --nvdec"
++SUBSYSTEM=="platform", DEVPATH=="/devices/platform/bus@0/*/154c0000.nvenc", ACTION=="bind|change", RUN+="/bin/bash /usr/libexec/nvpower.sh --nvenc"
++SUBSYSTEM=="hwmon", DEVPATH=="/devices/platform/bus@0/c600000.i2c/i2c-2/2-0044/hwmon/*", ACTION=="bind|change", RUN+="/bin/bash /usr/libexec/nvpower.sh --ina238"
++SUBSYSTEM=="net", KERNEL=="mgbe0_0", RUN+="/bin/bash /usr/libexec/nvpower.sh --mgbe"
++SUBSYSTEM=="net", KERNEL=="mgbe1_0", RUN+="/bin/bash /usr/libexec/nvpower.sh --mgbe"
++SUBSYSTEM=="net", KERNEL=="mgbe2_0", RUN+="/bin/bash /usr/libexec/nvpower.sh --mgbe"
++SUBSYSTEM=="net", KERNEL=="mgbe3_0", RUN+="/bin/bash /usr/libexec/nvpower.sh --mgbe"
+ 
+ LABEL="nvidia_end"

--- a/recipes-bsp/tegra-binaries/tegra-configs_38.2.2.bb
+++ b/recipes-bsp/tegra-binaries/tegra-configs_38.2.2.bb
@@ -21,6 +21,7 @@ SRC_URI[openrm.sha256sum] = "${OPENRMSUM}"
 
 SRC_URI += "\
     file://0001-Patch-nv-graphics.sh-script-for-OE-use.patch \
+    file://0001-Correct-path-to-nvpower.sh.patch \
     file://nv-l4t-bootloader-config.sh \
     file://devices.csv \
     file://drivers.csv \


### PR DESCRIPTION
The script 'nvpower.sh' is installed in path '/usr/libexec' bu tegra-nvpower recipe. The default path for Jetson Linux is '/etc/systemd' and this has to be adjusted in the udev rules.