### PR TITLE
tegra-flash-init: add partprobe during device export

### DIFF
--- a/recipes-core/initrdscripts/tegra-flash-init/init-flash.sh
+++ b/recipes-core/initrdscripts/tegra-flash-init/init-flash.sh
@@ -200,6 +200,7 @@ else
 		    if setup_usb_export /dev/$dev $dev 2>&1 > /tmp/flashpkg/flashpkg/logs/export-$dev.log; then
 			if wait_for_connect 2>&1 >> /tmp/flashpkg/flashpkg/logs/export-$dev.log; then
 			    if wait_for_disconnect 2>&1 >> /tmp/flashpkg/flashpkg/logs/export-$dev.log; then
+				partprobe /dev/$dev 2>&1 >> /tmp/flashpkg/flashpkg/logs/export-$dev.log
 				sgdisk /dev/$dev --verify 2>&1 >> /tmp/flashpkg/flashpkg/logs/export-$dev.log
 				sgdisk /dev/$dev --print 2>&1 >> /tmp/flashpkg/flashpkg/logs/export-$dev.log
 				continue

--- a/recipes-core/initrdscripts/tegra-flash-init_1.0.bb
+++ b/recipes-core/initrdscripts/tegra-flash-init_1.0.bb
@@ -39,7 +39,7 @@ do_install() {
 }
 
 FILES:${PN} = "/"
-RDEPENDS:${PN} = "util-linux-blkdiscard tegra-flash-reboot mtd-utils e2fsprogs-mke2fs libusbgx-tegra-initrd-flash watchdog-keepalive gptfdisk tegra-firmware kmod"
+RDEPENDS:${PN} = "util-linux-blkdiscard tegra-flash-reboot mtd-utils e2fsprogs-mke2fs libusbgx-tegra-initrd-flash watchdog-keepalive gptfdisk tegra-firmware kmod parted"
 RRECOMMENDS:${PN} = "kernel-module-loop \
                      kernel-module-libcomposite \
                      kernel-module-usb-f-mass-storage \


### PR DESCRIPTION
If a storage device has a partition table prior to being exported via USB, the kernel retains that original partition table after the USB export, regardless of what the host system writes to the device.

So once the export has been released by the host, run partprobe on the device to re-sync the kernel with the actual partition table, to avoid later confusion.