### PR TITLE
conf/machine: add configuration for Orin Nano SKU 0003

### DIFF
--- a/conf/machine/p3768-0000-p3767-0003.conf
+++ b/conf/machine/p3768-0000-p3767-0003.conf
@@ -1,0 +1,22 @@
+#@TYPE: Machine
+#@NAME: Nvidia Jetson Orin Nano 8GB (P3767-0003)
+#@DESCRIPTION: Nvidia Jetson Orin Nano 8G module in P3768 carrier
+
+TEGRA_FAB ?= "300"
+TEGRA_BOARDSKU ?= "0003"
+TEGRA_BOARDREV ?= "P.1"
+
+TEGRA_BUPGEN_SPECS ?= "fab=300;boardsku=0003;boardrev=;chipsku=00:00:00:D5;bup_type=bl \
+                       fab=300;boardsku=0003;boardrev=;bup_type=kernel"
+
+TNSPEC_BOOTDEV ?= "nvme0n1p1"
+PARTITION_LAYOUT_TEMPLATE_DEFAULT ?= "flash_t234_qspi.xml"
+PARTITION_LAYOUT_TEMPLATE_DEFAULT_SUPPORTS_REDUNDANT ?= "1"
+PARTITION_LAYOUT_EXTERNAL_DEFAULT ?= "flash_l4t_t234_nvme.xml"
+TEGRAFLASH_NO_INTERNAL_STORAGE = "1"
+
+MACHINEOVERRIDES =. "p3767-0003:"
+
+KERNEL_DEVICETREE ?= "tegra234-p3767-0003-super-p3768-0000-a0.dtb"
+
+require conf/machine/include/orin-nano.inc


### PR DESCRIPTION
Note, this is different than the SOM in the orin nano developer kit.

Backport of [1] with change to match Jetpack 5 KERNEL_DEVICETREE

1: https://github.com/OE4T/meta-tegra/commit/b746612d06b19c80abb4d2f6a5033333e9a9782d