### PR TITLE
linux-yocto: support macronix spi_nor flash and block protection

### DIFF
--- a/recipes-kernel/linux/linux-yocto/0010-UBUNTU-SAUCE-mtd-spi-nor-support-for-spansion-and-ma.patch
+++ b/recipes-kernel/linux/linux-yocto/0010-UBUNTU-SAUCE-mtd-spi-nor-support-for-spansion-and-ma.patch
@@ -1,0 +1,56 @@
+From 64ea19263c4ebf747132a59d4a7d8a083f1ac5a4 Mon Sep 17 00:00:00 2001
+From: Vishwaroop A <va@nvidia.com>
+Date: Mon, 27 Mar 2023 04:44:56 +0000
+Subject: [PATCH] UBUNTU: SAUCE: mtd: spi-nor: support for spansion and
+ macronix
+
+BugLink: https://bugs.launchpad.net/bugs/2015755
+
+Add flash info for spansion and macronix flash
+devices.
+
+Upstream-Status: Backport [5.15.148-1012.12]
+
+Signed-off-by: Vishwaroop A <va@nvidia.com>
+Reviewed-by: Laxman Dewangan <ldewangan@nvidia.com>
+Signed-off-by: Abhilash G <abhilashg@nvidia.com>
+Tested-by: Laxman Dewangan <ldewangan@nvidia.com>
+Signed-off-by: Abhilash G <abhilashg@nvidia.com>
+Acked-by: Brad Figg <bfigg@nvidia.com>
+Acked-by: Ian May <ian.may@canonical.com>
+Acked-by: Jacob Martin <jacob.martin@canonical.com>
+Signed-off-by: Brad Figg <bfigg@nvidia.com>
+---
+ drivers/mtd/spi-nor/macronix.c | 3 +++
+ drivers/mtd/spi-nor/spansion.c | 4 ++++
+ 2 files changed, 7 insertions(+)
+
+diff --git a/drivers/mtd/spi-nor/macronix.c b/drivers/mtd/spi-nor/macronix.c
+index eb149e517c1f..688ea179674e 100644
+--- a/drivers/mtd/spi-nor/macronix.c
++++ b/drivers/mtd/spi-nor/macronix.c
+@@ -82,6 +82,9 @@ static const struct flash_info macronix_nor_parts[] = {
+ 	{ "mx25u51245g", INFO(0xc2253a, 0, 64 * 1024, 1024)
+ 		NO_SFDP_FLAGS(SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ)
+ 		FIXUP_FLAGS(SPI_NOR_4B_OPCODES) },
++	{ "mx25u51279g", INFO(0xc2953a, 0, 64 * 1024, 1024)
++		NO_SFDP_FLAGS(SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ)
++		FIXUP_FLAGS(SPI_NOR_4B_OPCODES) },
+ 	{ "mx25uw51245g", INFOB(0xc2813a, 0, 0, 0, 4)
+ 		PARSE_SFDP
+ 		FLAGS(SPI_NOR_RWW) },
+diff --git a/drivers/mtd/spi-nor/spansion.c b/drivers/mtd/spi-nor/spansion.c
+index 828b442735ee..c34f2d3f6637 100644
+--- a/drivers/mtd/spi-nor/spansion.c
++++ b/drivers/mtd/spi-nor/spansion.c
+@@ -802,6 +802,10 @@ static const struct flash_info spansion_nor_parts[] = {
+ 		NO_SFDP_FLAGS(SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ)
+ 		MFR_FLAGS(USE_CLSR)
+ 		.fixups = &s25fs_s_nor_fixups, },
++	{ "s25fs512s1", INFO(0x010220, 0x4d0181, 64 * 1024, 1024)
++		NO_SFDP_FLAGS(SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ)
++		MFR_FLAGS(USE_CLSR)
++		.fixups = &s25fs_s_nor_fixups, },
+ 	{ "s25sl12800", INFO(0x012018, 0x0300, 256 * 1024,  64) },
+ 	{ "s25sl12801", INFO(0x012018, 0x0301,  64 * 1024, 256) },
+ 	{ "s25fl129p0", INFO(0x012018, 0x4d00, 256 * 1024,  64)

--- a/recipes-kernel/linux/linux-yocto/0011-NVIDIA-SAUCE-enable-handling-of-macronix-block-prote.patch
+++ b/recipes-kernel/linux/linux-yocto/0011-NVIDIA-SAUCE-enable-handling-of-macronix-block-prote.patch
@@ -1,0 +1,57 @@
+From 76a3408f4d886805371d06107d9ee4f2700f0f98 Mon Sep 17 00:00:00 2001
+From: Brad Griffis <bgriffis@nvidia.com>
+Date: Wed, 10 Apr 2024 18:02:21 +0000
+Subject: [PATCH] NVIDIA: SAUCE: enable handling of macronix block protection
+
+BugLink: https://bugs.launchpad.net/bugs/2061900
+
+Orin NX/Nano modules have been shipping with block protection enabled.
+That is changing and the modules will ship with the block protection
+disabled.
+
+Note that the QSPI driver is only used during initrd flashing (rcm
+boot). On regular cold boot the QSPI node is disabled by UEFI to
+prevent access.
+
+This patch is not expected to be applied to future kernels since by
+that time there will no longer be units with block protection enabled.
+
+Adjust the driver configuration to handle block protection. Set the
+following flags for mx25u51279g:
+
+* SPI_NOR_HAS_LOCK
+    The macronix driver doesn't define a locking_ops structure so
+    there is no code specified to actually perform the lock/unlock
+    operations. SPI_NOR_HAS_LOCK causes the function
+    spi_nor_init_default_locking_ops() to be run which assigns
+    functions to perform lock/unlock operations.
+
+* SPI_NOR_SWP_IS_VOLATILE
+    Setting this flag causes the function spi_nor_try_unlock_all()
+    to be run, which clears the block protect bits.
+
+Upstream-Status: Backport [5.15.148-1012.12]
+
+Signed-off-by: Brad Griffis <bgriffis@nvidia.com>
+Reviewed-by: Hiteshkumar Patel <hiteshkumarg@nvidia.com>
+Reviewed-by: Jon Hunter <jonathanh@nvidia.com>
+Reviewed-by: Dipen Patel <dipenp@nvidia.com>
+Acked-by: Noah Wager <noah.wager@canonical.com>
+Acked-by: Jacob Martin <jacob.martin@canonical.com>
+Signed-off-by: Noah Wager <noah.wager@canonical.com>
+---
+ drivers/mtd/spi-nor/macronix.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/mtd/spi-nor/macronix.c b/drivers/mtd/spi-nor/macronix.c
+index 688ea179674e..e3ba4b5642cd 100644
+--- a/drivers/mtd/spi-nor/macronix.c
++++ b/drivers/mtd/spi-nor/macronix.c
+@@ -83,6 +83,7 @@ static const struct flash_info macronix_nor_parts[] = {
+ 		NO_SFDP_FLAGS(SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ)
+ 		FIXUP_FLAGS(SPI_NOR_4B_OPCODES) },
+ 	{ "mx25u51279g", INFO(0xc2953a, 0, 64 * 1024, 1024)
++		FLAGS(SPI_NOR_HAS_LOCK | SPI_NOR_SWP_IS_VOLATILE)
+ 		NO_SFDP_FLAGS(SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ)
+ 		FIXUP_FLAGS(SPI_NOR_4B_OPCODES) },
+ 	{ "mx25uw51245g", INFOB(0xc2813a, 0, 0, 0, 4)

--- a/recipes-kernel/linux/linux-yocto_6.6.bbappend
+++ b/recipes-kernel/linux/linux-yocto_6.6.bbappend
@@ -12,6 +12,8 @@ SRC_URI:append:tegra = " \
     file://0007-fbdev-simplefb-Add-support-for-generic-power-domains.patch \
     file://0008-UBUNTU-SAUCE-PCI-endpoint-Add-core_deinit-callback-s.patch \
     file://0009-NVIDIA-SAUCE-soc-tegra-pmc-Add-sysfs-nodes-to-select.patch \
+    file://0010-UBUNTU-SAUCE-mtd-spi-nor-support-for-spansion-and-ma.patch \
+    file://0011-NVIDIA-SAUCE-enable-handling-of-macronix-block-prote.patch \
     file://tegra.cfg \
     file://tegra-drm.cfg \
     file://tegra-governors.cfg \


### PR DESCRIPTION
Blank Orin NX modules from the factory have the block protection enabled in their flash devices. Using the linux-yocto kernel in an initrd-flash image would not properly handle this.

Port two patches from the Jammy kernel to add support for the flash part (Macronix S25FS512S1) and the block protection bits so that initrd-flash can work using linux-yocto.

https://github.com/orgs/OE4T/discussions/1740