### PR TITLE
linux-yocto: support macronix spi_nor flash and block protection

### DIFF
--- a/recipes-kernel/linux/linux-yocto-6.12/0002-UBUNTU-SAUCE-mtd-spi-nor-support-for-spansion-and-ma.patch
+++ b/recipes-kernel/linux/linux-yocto-6.12/0002-UBUNTU-SAUCE-mtd-spi-nor-support-for-spansion-and-ma.patch
@@ -1,0 +1,66 @@
+From 079697c3bd71134af9debb41974632e23da29434 Mon Sep 17 00:00:00 2001
+From: Vishwaroop A <va@nvidia.com>
+Date: Mon, 27 Mar 2023 04:44:56 +0000
+Subject: [PATCH 1/2] UBUNTU: SAUCE: mtd: spi-nor: support for spansion and
+ macronix
+
+BugLink: https://bugs.launchpad.net/bugs/2015755
+
+Add flash info for spansion and macronix flash
+devices.
+
+Upstream-Status: Backport [5.15.148-1012.12]
+
+Signed-off-by: Vishwaroop A <va@nvidia.com>
+Reviewed-by: Laxman Dewangan <ldewangan@nvidia.com>
+Signed-off-by: Abhilash G <abhilashg@nvidia.com>
+Tested-by: Laxman Dewangan <ldewangan@nvidia.com>
+Signed-off-by: Abhilash G <abhilashg@nvidia.com>
+Acked-by: Brad Figg <bfigg@nvidia.com>
+Acked-by: Ian May <ian.may@canonical.com>
+Acked-by: Jacob Martin <jacob.martin@canonical.com>
+Signed-off-by: Brad Figg <bfigg@nvidia.com>
+---
+ drivers/mtd/spi-nor/macronix.c | 6 ++++++
+ drivers/mtd/spi-nor/spansion.c | 8 ++++++++
+ 2 files changed, 14 insertions(+)
+
+diff --git a/drivers/mtd/spi-nor/macronix.c b/drivers/mtd/spi-nor/macronix.c
+index ea6be95e75a52..f2b0a72721985 100644
+--- a/drivers/mtd/spi-nor/macronix.c
++++ b/drivers/mtd/spi-nor/macronix.c
+@@ -177,6 +177,12 @@ static const struct flash_info macronix_nor_parts[] = {
+ 		.name = "mx25uw51245g",
+ 		.n_banks = 4,
+ 		.flags = SPI_NOR_RWW,
++	}, {
++		.id = SNOR_ID(0xc2, 0x95, 0x3a),
++		.name = "mx25u51279g",
++		.size = SZ_64M,
++		.no_sfdp_flags = SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ,
++		.fixup_flags = SPI_NOR_4B_OPCODES,
+ 	}, {
+ 		.id = SNOR_ID(0xc2, 0x9e, 0x16),
+ 		.name = "mx25l3255e",
+diff --git a/drivers/mtd/spi-nor/spansion.c b/drivers/mtd/spi-nor/spansion.c
+index 5a88a6096ca8c..92b89169415bd 100644
+--- a/drivers/mtd/spi-nor/spansion.c
++++ b/drivers/mtd/spi-nor/spansion.c
+@@ -831,6 +831,14 @@ static const struct flash_info spansion_nor_parts[] = {
+ 		.no_sfdp_flags = SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ,
+ 		.mfr_flags = USE_CLSR,
+ 		.fixups = &s25fs_s_nor_fixups,
++	}, {
++		.id = SNOR_ID(0x01, 0x02, 0x20, 0x4d, 0x01, 0x80),
++		.name = "s25fs512s1",
++		.size = SZ_64M,
++		.sector_size = SZ_1M,
++		.no_sfdp_flags = SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ,
++		.mfr_flags = USE_CLSR,
++		.fixups = &s25fs_s_nor_fixups,
+ 	}, {
+ 		.id = SNOR_ID(0x01, 0x20, 0x18, 0x03, 0x00),
+ 		.name = "s25sl12800",
+-- 
+2.34.1
+

--- a/recipes-kernel/linux/linux-yocto-6.12/0003-NVIDIA-SAUCE-enable-handling-of-macronix-block-prote.patch
+++ b/recipes-kernel/linux/linux-yocto-6.12/0003-NVIDIA-SAUCE-enable-handling-of-macronix-block-prote.patch
@@ -1,0 +1,61 @@
+From efb7403d9b4fdd86ea4c86100362b7d6d6ec096f Mon Sep 17 00:00:00 2001
+From: Brad Griffis <bgriffis@nvidia.com>
+Date: Wed, 10 Apr 2024 18:02:21 +0000
+Subject: [PATCH 2/2] NVIDIA: SAUCE: enable handling of macronix block
+ protection
+
+BugLink: https://bugs.launchpad.net/bugs/2061900
+
+Orin NX/Nano modules have been shipping with block protection enabled.
+That is changing and the modules will ship with the block protection
+disabled.
+
+Note that the QSPI driver is only used during initrd flashing (rcm
+boot). On regular cold boot the QSPI node is disabled by UEFI to
+prevent access.
+
+This patch is not expected to be applied to future kernels since by
+that time there will no longer be units with block protection enabled.
+
+Adjust the driver configuration to handle block protection. Set the
+following flags for mx25u51279g:
+
+* SPI_NOR_HAS_LOCK
+    The macronix driver doesn't define a locking_ops structure so
+    there is no code specified to actually perform the lock/unlock
+    operations. SPI_NOR_HAS_LOCK causes the function
+    spi_nor_init_default_locking_ops() to be run which assigns
+    functions to perform lock/unlock operations.
+
+* SPI_NOR_SWP_IS_VOLATILE
+    Setting this flag causes the function spi_nor_try_unlock_all()
+    to be run, which clears the block protect bits.
+
+Upstream-Status: Backport [5.15.148-1012.12]
+
+Signed-off-by: Brad Griffis <bgriffis@nvidia.com>
+Reviewed-by: Hiteshkumar Patel <hiteshkumarg@nvidia.com>
+Reviewed-by: Jon Hunter <jonathanh@nvidia.com>
+Reviewed-by: Dipen Patel <dipenp@nvidia.com>
+Acked-by: Noah Wager <noah.wager@canonical.com>
+Acked-by: Jacob Martin <jacob.martin@canonical.com>
+Signed-off-by: Noah Wager <noah.wager@canonical.com>
+---
+ drivers/mtd/spi-nor/macronix.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/mtd/spi-nor/macronix.c b/drivers/mtd/spi-nor/macronix.c
+index f2b0a72721985..03fa380355f7f 100644
+--- a/drivers/mtd/spi-nor/macronix.c
++++ b/drivers/mtd/spi-nor/macronix.c
+@@ -181,6 +181,7 @@ static const struct flash_info macronix_nor_parts[] = {
+ 		.id = SNOR_ID(0xc2, 0x95, 0x3a),
+ 		.name = "mx25u51279g",
+ 		.size = SZ_64M,
++		.flags = SPI_NOR_HAS_LOCK | SPI_NOR_SWP_IS_VOLATILE,
+ 		.no_sfdp_flags = SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ,
+ 		.fixup_flags = SPI_NOR_4B_OPCODES,
+ 	}, {
+-- 
+2.34.1
+

--- a/recipes-kernel/linux/linux-yocto_6.12.bbappend
+++ b/recipes-kernel/linux/linux-yocto_6.12.bbappend
@@ -4,6 +4,8 @@ require ${@'tegra-kernel.inc' if 'tegra' in d.getVar('MACHINEOVERRIDES').split('
 
 SRC_URI:append:tegra = " \
     file://0001-NVIDIA-SAUCE-soc-tegra-pmc-Add-sysfs-nodes-to-select.patch \
+    file://0002-UBUNTU-SAUCE-mtd-spi-nor-support-for-spansion-and-ma.patch \
+    file://0003-NVIDIA-SAUCE-enable-handling-of-macronix-block-prote.patch \
     file://tegra.cfg \
     file://tegra-drm.cfg \
     file://tegra-governors.cfg \


### PR DESCRIPTION
Blank Orin NX modules from the factory have the block protection enabled in their flash devices. Using the linux-yocto kernel in an initrd-flash image would not properly handle this.

Port two patches from the Jammy kernel to add support for the flash part (Macronix S25FS512S1) and the block protection bits so that initrd-flash can work using linux-yocto.

https://github.com/orgs/OE4T/discussions/1740