### PR TITLE
tegra-tools: package fuse and dram-info tools

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-tools_36.4.4.bb
+++ b/recipes-bsp/tegra-binaries/tegra-tools_36.4.4.bb
@@ -11,12 +11,17 @@ do_install() {
     install -d ${D}${bindir}
     install -m 0755 ${S}/usr/bin/tegrastats ${D}${bindir}/
     install -m 0755 ${S}/usr/bin/jetson_clocks ${D}${bindir}/
+    install -m 0755 -D -t ${D}${sbindir} ${S}/usr/sbin/nv_get_dram_info ${S}/usr/sbin/nv_fuse_read.sh
 }
 
-PACKAGES = "${PN}-tegrastats ${PN}-jetson-clocks ${PN}"
+PACKAGES = "${PN}-tegrastats ${PN}-jetson-clocks ${PN}-fuse-read ${PN}-dram-info ${PN}"
 ALLOW_EMPTY:${PN} = "1"
-RDEPENDS:${PN} = "${PN}-tegrastats ${PN}-jetson-clocks"
+RDEPENDS:${PN} = "${PN}-tegrastats ${PN}-jetson-clocks ${PN}-fuse-read ${PN}-dram-info"
 FILES:${PN}-tegrastats = "${bindir}/tegrastats"
 INSANE_SKIP:${PN}-tegrastats = "ldflags"
 FILES:${PN}-jetson-clocks = "${bindir}/jetson_clocks"
 RDEPENDS:${PN}-jetson-clocks = "bash"
+FILES:${PN}-fuse-read = "${sbindir}/nv_fuse_read.sh"
+RDEPENDS:${PN}-fuse-read = "bash xxd coreutils"
+FILES:${PN}-dram-info = "${sbindir}/nv_get_dram_info"
+INSANE_SKIP:${PN}-dram-info = "ldflags"


### PR DESCRIPTION
The nv_fuse_read.sh script can be used to examine the fuses exported by the tegra fuse driver through an nvmem devicde.

The nv_dram_info program may or may not work with the latest L4T releases, but is supposed to display info about the DRAM installed on the module.