### PR TITLE
uefi: allow for adding config fragments to SRC_URI

### DIFF
--- a/recipes-bsp/uefi/edk2-firmware-tegra-36.4.4.inc
+++ b/recipes-bsp/uefi/edk2-firmware-tegra-36.4.4.inc
@@ -91,3 +91,7 @@ EDK2_EXTRA_BUILD = '-D "BUILDID_STRING=v${PV}" -D "BUILD_DATE_TIME=${@format_bui
 def format_build_date(d):
     import datetime
     return datetime.datetime.fromtimestamp(int(d.getVar("SOURCE_DATE_EPOCH")), datetime.timezone.utc).replace(microsecond=0).isoformat()
+
+def config_fragments(d):
+    import oe.patch
+    return ' '.join([frag_file for frag_file in oe.patch.src_patches(d, all=True, expand=True) if os.path.splitext(frag_file)[1] == ".cfg"])

--- a/recipes-bsp/uefi/edk2-firmware-tegra-minimal_36.4.4.bb
+++ b/recipes-bsp/uefi/edk2-firmware-tegra-minimal_36.4.4.bb
@@ -14,7 +14,7 @@ EDK2_BIN_NAME = "uefi_jetson_minimal.bin"
 SRC_URI += "file://nvbuildconfig.py"
 
 do_configure:append() {
-    ${PYTHON} ${WORKDIR}/nvbuildconfig.py ${S_EDK2_NVIDIA}/Platform/NVIDIA/Kconfig ${S_EDK2_NVIDIA}/Platform/NVIDIA/${EDK2_PLATFORM}/Jetson.defconfig ${B}/nvidia-config/Jetson/.config ${B}/nvidia-config/Jetson/config.dsc.inc
+    ${PYTHON} ${WORKDIR}/nvbuildconfig.py --kconfig-path=${S_EDK2_NVIDIA}/Platform/NVIDIA/Kconfig --output-dir=${B}/nvidia-config/Jetson ${S_EDK2_NVIDIA}/Platform/NVIDIA/${EDK2_PLATFORM}/Jetson.defconfig ${@config_fragments(d)}
 }
 
 do_compile:append() {

--- a/recipes-bsp/uefi/edk2-firmware-tegra_36.4.4.bb
+++ b/recipes-bsp/uefi/edk2-firmware-tegra_36.4.4.bb
@@ -17,7 +17,7 @@ EDK2_BIN_NAME = "uefi_jetson.bin"
 SRC_URI += "file://nvbuildconfig.py"
 
 do_configure:append() {
-    ${PYTHON} ${WORKDIR}/nvbuildconfig.py ${S_EDK2_NVIDIA}/Platform/NVIDIA/Kconfig ${S_EDK2_NVIDIA}/Platform/NVIDIA/${EDK2_PLATFORM}/Jetson.defconfig ${B}/nvidia-config/Jetson/.config ${B}/nvidia-config/Jetson/config.dsc.inc
+    ${PYTHON} ${WORKDIR}/nvbuildconfig.py --kconfig-path=${S_EDK2_NVIDIA}/Platform/NVIDIA/Kconfig --output-dir=${B}/nvidia-config/Jetson ${S_EDK2_NVIDIA}/Platform/NVIDIA/${EDK2_PLATFORM}/Jetson.defconfig ${@config_fragments(d)}
 }
 
 def fmp_lowest_version(d):

--- a/recipes-bsp/uefi/files/nvbuildconfig.py
+++ b/recipes-bsp/uefi/files/nvbuildconfig.py
@@ -1,23 +1,20 @@
 import sys
 import os
+import argparse
 from kconfiglib import Kconfig
 
 # Adapted from edk2-nvidia/Silicon/NVIDIA/edk2nv/stuart/builder.py BuildConfigFile method
-def build_config_file(kconf_path, defconfig_file, config_out):
+def build_config_file(kconf_path, configs, config_out):
     kconf = Kconfig(kconf_path, warn_to_stderr=False,
                     suppress_traceback=True)
     kconf.warn_assign_undef = True
     kconf.warn_assign_override = False
     kconf.warn_assign_redun = False
 
-    configs = [defconfig_file]
     print(kconf.load_config(configs[0]))
     for config in configs[1:]:
         # replace=False creates a merged configuration
         print(kconf.load_config(config, replace=False))
-
-    if os.path.exists(config_out):
-        print(kconf.load_config(config_out, replace=False))
 
     kconf.write_config(os.devnull)
 
@@ -38,8 +35,29 @@ def build_config_file(kconf_path, defconfig_file, config_out):
     print(kconf.write_config(config_out))
     return 0
 
-build_config_file(sys.argv[1], sys.argv[2], sys.argv[3])
+def main():
+    parser = argparse.ArgumentParser(description="Configuration merge tool for NVIDIA UEFI/EDK2 builds")
+    parser.add_argument("--kconfig-path", help="path to base Kconfig file", required=True)
+    parser.add_argument("--output-directory", help="directory for writing .config and config.dsc.inc files")
+    parser.add_argument("config_files", nargs="+")
+    args = parser.parse_args()
+    if args.output_directory:
+        output_file = os.path.join(args.output_directory, ".config")
+        output_dsc = os.path.join(args.output_directory, "config.dsc.inc")
+    else:
+        output_file = ".config"
+        output_dsc = "config.dsc.inc"
+    build_config_file(args.kconfig_path, args.config_files, output_file)
+    with open(output_file, "r") as f, open(output_dsc, "w") as fo:
+        for line in f:
+            fo.write(line.replace('"', '').replace("'", ""))
+    return 0
 
-with open(sys.argv[3], "r") as f, open(sys.argv[4], "w") as fo:
-    for line in f:
-        fo.write(line.replace('"', '').replace("'", ""))
+if __name__ == '__main__':
+    try:
+        ret = main()
+    except Exception:
+        ret = 1
+        import traceback
+        traceback.print_exc()
+    sys.exit(ret)


### PR DESCRIPTION
NVIDIA added some Kconfig-style configuration handling to their UEFI builds, and we can allow for users to supply `.cfg` fragment files to override build configuration, similar to the kernel or U-Boot.

Tweak the Python script we provide to process the configuration files so it can take multiple arguments for config merging, and update the do_configure append in each of the two recipes so it passes any config fragments listed in the SRC_URI to the script.

Back-port of #2105 