### PR TITLE
tegra-bootfiles: add mechanism for disabling boot logging

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-bootfiles_36.4.4.bb
+++ b/recipes-bsp/tegra-binaries/tegra-bootfiles_36.4.4.bb
@@ -12,6 +12,10 @@ TEGRA_SOCNAME_SHORT = "${@d.getVar('SOC_FAMILY')[0:1] + d.getVar('SOC_FAMILY')[-
 BACKSLASH_X_01 = "${@'\\' + 'x01'}"
 BADPAGE_SIZE = "8192"
 
+TEGRA_MB1_LOG_LEVEL ??= "4"
+TEGRA_MB1_MISC_CONFIG_SECTION ?= "misc"
+TEGRA_BPMP_SERIAL_LOGGING ??= "1"
+
 do_compile() {
     prepare_badpage_mapfile
 }
@@ -63,6 +67,18 @@ install_other_boot_firmware_files() {
 	    ;;
     esac
     install -m 0644 ${B}/badpage.bin ${D}${datadir}/tegraflash/
+    cat >> ${D}${datadir}/tegraflash/${TEGRA_FLASHVAR_MISC_CONFIG} <<EOF
+/ {
+        ${TEGRA_MB1_MISC_CONFIG_SECTION} {
+                debug {
+                        log_level = <${TEGRA_MB1_LOG_LEVEL}>;
+                };
+        };
+};
+EOF
+    if ${@'false' if bb.utils.to_boolean(d.getVar('TEGRA_BPMP_SERIAL_LOGGING')) else 'true'}; then
+        fdtput -r ${D}${datadir}/tegraflash/${TEGRA_FLASHVAR_BPFDTB_FILE} /serial
+    fi
 }
 
 PACKAGES = "${PN}-dev"


### PR DESCRIPTION
One way to reduce boot time is to disable logging to the serial console. There is a "log_level" setting in the TEGRA_FLASHVAR_MISC_CONFIG device tree file to control the log level for the mb1/mb2 boot loaders, and for the BPMP, removing the entire "serial" node from BPMP device tree (TEGRA_FLASHVAR_BPFDTB_FILE) disables its logging.

This patch adds variables for easily disabling these two logging sources:

TEGRA_MB1_LOG_LEVEL: set to 0 to turn off mb1/mb2 logging (default: 4)
TEGRA_BPMP_SERIAL_LOGGING: set to 0/false/off to turn off BPMP logging
                           (default: 1)

Note that the boot time savings is only a few seconds or so, and the logging can help with troubleshooting boot failures.