### PR TITLE
nvidia-kernel-oot: rework patches to be able to use devtool

### DIFF
--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0001-Fix-build-warning-on-rtl8852ce-driver.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0001-Fix-build-warning-on-rtl8852ce-driver.patch
@@ -1,0 +1,38 @@
+From c0fd33a195288fe8bc709f219af1fea892b1c156 Mon Sep 17 00:00:00 2001
+From: Ilies CHERGUI <ichergui@nvidia.com>
+Date: Thu, 15 Jan 2026 14:46:40 -0800
+Subject: [PATCH] Fix build warning on rtl8852ce driver
+
+Upstream-Status: Pending
+
+Signed-off-by: Matt Madison <matt@madison.systems>
+Signed-off-by: Ilies CHERGUI <ichergui@nvidia.com>
+---
+ .../phy/rf/halrf_8852c/halrf_ops_rtl8852c.h   | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/net/wireless/realtek/rtl8852ce/phl/hal_g6/phy/rf/halrf_8852c/halrf_ops_rtl8852c.h b/drivers/net/wireless/realtek/rtl8852ce/phl/hal_g6/phy/rf/halrf_8852c/halrf_ops_rtl8852c.h
+index 7966290..b4b92ad 100644
+--- a/drivers/net/wireless/realtek/rtl8852ce/phl/hal_g6/phy/rf/halrf_8852c/halrf_ops_rtl8852c.h
++++ b/drivers/net/wireless/realtek/rtl8852ce/phl/hal_g6/phy/rf/halrf_8852c/halrf_ops_rtl8852c.h
+@@ -22,13 +22,13 @@
+  * Larry Finger <Larry.Finger@lwfinger.net>
+  *
+  *****************************************************************************/
+-#ifndef __HALRF_OPS_RTL8852C_H__
+-#define __HALRF_OPS_RTL8852C__
++#ifndef HALRF_OPS_RTL8852C_H
++#define HALRF_OPS_RTL8852C_H
+ #ifdef RF_8852C_SUPPORT
+
+
+ void rf_set_ops_8852c(struct rf_info *rf) ;
+
+
+-#endif
+-#endif /*  __HALRF_OPS_RTL8852C_H__ */
++#endif /* RF_8852C_SUPPORT */
++#endif /* HALRF_OPS_RTL8852C_H */
+--
+2.34.1
+

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0001-Makefile-update-for-OE-builds.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0001-Makefile-update-for-OE-builds.patch
@@ -14,16 +14,13 @@ Subject: [PATCH] Makefile: update for OE builds
   to prevent some compilation failures due gcc warning-to-error
   changes in later versions of the compiler
 
-* Fix build warning on rtl8852ce driver
-
 Upstream-Status: Pending
 
 Signed-off-by: Matt Madison <matt@madison.systems>
 Signed-off-by: Ilies CHERGUI <ichergui@nvidia.com>
 ---
- Makefile                                      | 78 +++++++++++--------
- .../phy/rf/halrf_8852c/halrf_ops_rtl8852c.h   |  8 +-
- 2 files changed, 49 insertions(+), 37 deletions(-)
+ Makefile | 78 +++++++++++++++++++++++++++++---------------------------
+ 1 file changed, 41 insertions(+), 37 deletions(-)
 
 diff --git a/Makefile b/Makefile
 index 24ee6c5..b915c67 100644
@@ -188,28 +185,6 @@ index 24ee6c5..b915c67 100644
  	$(MAKE) -f $(NVIDIA_DTS_BUILD_SCRIPTS)/scripts/Makefile.build \
  		obj=$(NVIDIA_DTS_BUILD_SCRIPTS)/generic-dts \
  		dtbs
-diff --git a/nvidia-oot/drivers/net/wireless/realtek/rtl8852ce/phl/hal_g6/phy/rf/halrf_8852c/halrf_ops_rtl8852c.h b/nvidia-oot/drivers/net/wireless/realtek/rtl8852ce/phl/hal_g6/phy/rf/halrf_8852c/halrf_ops_rtl8852c.h
-index 7966290..b4b92ad 100644
---- a/nvidia-oot/drivers/net/wireless/realtek/rtl8852ce/phl/hal_g6/phy/rf/halrf_8852c/halrf_ops_rtl8852c.h
-+++ b/nvidia-oot/drivers/net/wireless/realtek/rtl8852ce/phl/hal_g6/phy/rf/halrf_8852c/halrf_ops_rtl8852c.h
-@@ -22,13 +22,13 @@
-  * Larry Finger <Larry.Finger@lwfinger.net>
-  *
-  *****************************************************************************/
--#ifndef __HALRF_OPS_RTL8852C_H__
--#define __HALRF_OPS_RTL8852C__
-+#ifndef HALRF_OPS_RTL8852C_H
-+#define HALRF_OPS_RTL8852C_H
- #ifdef RF_8852C_SUPPORT
- 
- 
- void rf_set_ops_8852c(struct rf_info *rf) ;
- 
- 
--#endif
--#endif /*  __HALRF_OPS_RTL8852C_H__ */
-+#endif /* RF_8852C_SUPPORT */
-+#endif /* HALRF_OPS_RTL8852C_H */
--- 
+--
 2.34.1
 

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0002-Fix-nvdisplay-modules-builds.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0002-Fix-nvdisplay-modules-builds.patch
@@ -11,30 +11,17 @@ Upstream-Status: Inappropriate [OE specific]
 
 Signed-off-by: Matt Madison <matt@madison.systems>
 ---
- Makefile                          |  1 +
- nvdisplay/kernel-open/Kbuild      | 15 ++++++++-------
- nvdisplay/kernel-open/Makefile    |  1 +
- nvdisplay/kernel-open/conftest.sh | 32 +++++++++++++++++--------------
- 4 files changed, 28 insertions(+), 21 deletions(-)
+ kernel-open/Kbuild      | 15 ++++++++-------
+ kernel-open/Makefile    |  1 +
+ kernel-open/conftest.sh | 32 +++++++++++++++++--------------
+ 3 files changed, 27 insertions(+), 21 deletions(-)
 
-diff --git a/Makefile b/Makefile
-index b915c67..9979b43 100644
---- a/Makefile
-+++ b/Makefile
-@@ -134,6 +134,7 @@ define display-cmd
- 		SYSSRCNVOOT=$(MAKEFILE_DIR)/nvidia-oot \
- 		SYSSRC=$(KERNEL_SRC) \
- 		SYSOUT=$(KBUILD_OUTPUT) \
-+		OOTSRC=$(MAKEFILE_DIR)/nvidia-oot \
- 		KBUILD_EXTRA_SYMBOLS=$(MAKEFILE_DIR)/nvidia-oot/Module.symvers \
- 		CC="$(CC)" \
- 		LD="$(LD)" \
-diff --git a/nvdisplay/kernel-open/Kbuild b/nvdisplay/kernel-open/Kbuild
+diff --git a/kernel-open/Kbuild b/kernel-open/Kbuild
 index 1b07b82..87ff3cc 100644
---- a/nvdisplay/kernel-open/Kbuild
-+++ b/nvdisplay/kernel-open/Kbuild
+--- a/kernel-open/Kbuild
++++ b/kernel-open/Kbuild
 @@ -77,6 +77,7 @@ $(foreach _module, $(NV_KERNEL_MODULES), \
- 
+
  ccflags-y += -I$(src)/common/inc
  ccflags-y += -I$(src)
 +ccflags-y += -I$(NV_OOT_SOURCES)/include
@@ -89,11 +76,11 @@ index 1b07b82..87ff3cc 100644
 +	$(NV_CONFTEST_CMD) $@ full_output
  
  # Perform all sanity checks before generating the conftest headers
- 
-diff --git a/nvdisplay/kernel-open/Makefile b/nvdisplay/kernel-open/Makefile
+
+diff --git a/kernel-open/Makefile b/kernel-open/Makefile
 index 1b98d33..fe0b40d 100644
---- a/nvdisplay/kernel-open/Makefile
-+++ b/nvdisplay/kernel-open/Makefile
+--- a/kernel-open/Makefile
++++ b/kernel-open/Makefile
 @@ -129,6 +129,7 @@ else
    KBUILD_PARAMS += ARCH=$(ARCH)
    KBUILD_PARAMS += NV_KERNEL_SOURCES=$(KERNEL_SOURCES)
@@ -102,10 +89,10 @@ index 1b98d33..fe0b40d 100644
    KBUILD_PARAMS += NV_KERNEL_MODULES="$(NV_KERNEL_MODULES)"
    KBUILD_PARAMS += INSTALL_MOD_DIR="$(INSTALL_MOD_DIR)"
    KBUILD_PARAMS += NV_SPECTRE_V2=$(SPECTRE_V2_RETPOLINE)
-diff --git a/nvdisplay/kernel-open/conftest.sh b/nvdisplay/kernel-open/conftest.sh
+diff --git a/kernel-open/conftest.sh b/kernel-open/conftest.sh
 index c4171a0..9c34e18 100755
---- a/nvdisplay/kernel-open/conftest.sh
-+++ b/nvdisplay/kernel-open/conftest.sh
+--- a/kernel-open/conftest.sh
++++ b/kernel-open/conftest.sh
 @@ -11,6 +11,8 @@ ARCH=$2
  SOURCES=$3
  HEADERS=$SOURCES/include

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0002-Makefile-Add-OOTSRC-for-nvdisplay-builds.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0002-Makefile-Add-OOTSRC-for-nvdisplay-builds.patch
@@ -1,0 +1,27 @@
+From 885fe8d6600f9ed8075fac1c86065da578d69e3e Mon Sep 17 00:00:00 2001
+From: Ilies CHERGUI <ichergui@nvidia.com>
+Date: Thu, 15 Jan 2026 12:45:54 -0800
+Subject: [PATCH] Makefile: Add OOTSRC for nvdisplay builds
+
+Upstream-Status: Inappropriate [OE specific]
+
+Signed-off-by: Matt Madison <matt@madison.systems>
+---
+ Makefile | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/Makefile b/Makefile
+index b915c67..9979b43 100644
+--- a/Makefile
++++ b/Makefile
+@@ -134,6 +134,7 @@ define display-cmd
+ 		SYSSRCNVOOT=$(MAKEFILE_DIR)/nvidia-oot \
+ 		SYSSRC=$(KERNEL_SRC) \
+ 		SYSOUT=$(KBUILD_OUTPUT) \
++		OOTSRC=$(MAKEFILE_DIR)/nvidia-oot \
+ 		KBUILD_EXTRA_SYMBOLS=$(MAKEFILE_DIR)/nvidia-oot/Module.symvers \
+ 		CC="$(CC)" \
+ 		LD="$(LD)" \
+--
+2.34.1
+

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0003-Fix-nvdisplay-conftest-gcc-14-compatibility-issues.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0003-Fix-nvdisplay-conftest-gcc-14-compatibility-issues.patch
@@ -7,13 +7,13 @@ Upstream-Status: Inappropriate [OE specific]
 
 Signed-off-by: Matt Madison <matt@madison.systems>
 ---
- nvdisplay/kernel-open/conftest.sh | 4 ++--
+ kernel-open/conftest.sh | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)
 
-diff --git a/nvdisplay/kernel-open/conftest.sh b/nvdisplay/kernel-open/conftest.sh
-index 3f42ff2..12acf19 100755
---- a/nvdisplay/kernel-open/conftest.sh
-+++ b/nvdisplay/kernel-open/conftest.sh
+diff --git a/kernel-open/conftest.sh b/kernel-open/conftest.sh
+index 9c34e18..12acf19 100755
+--- a/kernel-open/conftest.sh
++++ b/kernel-open/conftest.sh
 @@ -106,8 +106,8 @@ build_cflags() {
      ISYSTEM=`$CC -print-file-name=include 2> /dev/null`
      BASE_CFLAGS="-O2 -D__KERNEL__ \

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0004-Fix-unifiedgpudisp-modules-builds.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0004-Fix-unifiedgpudisp-modules-builds.patch
@@ -11,17 +11,17 @@ Upstream-Status: Inappropriate [OE specific]
 
 Signed-off-by: Ilies CHERGUI <ichergui@nvidia.com>
 ---
- unifiedgpudisp/kernel-open/Kbuild      | 15 ++++++------
- unifiedgpudisp/kernel-open/Makefile    |  1 +
- unifiedgpudisp/kernel-open/conftest.sh | 32 +++++++++++++++-----------
+ kernel-open/Kbuild      | 15 ++++++------
+ kernel-open/Makefile    |  1 +
+ kernel-open/conftest.sh | 32 +++++++++++++++-----------
  3 files changed, 27 insertions(+), 21 deletions(-)
 
-diff --git a/unifiedgpudisp/kernel-open/Kbuild b/unifiedgpudisp/kernel-open/Kbuild
+diff --git a/kernel-open/Kbuild b/kernel-open/Kbuild
 index 710570f..9ade365 100644
---- a/unifiedgpudisp/kernel-open/Kbuild
-+++ b/unifiedgpudisp/kernel-open/Kbuild
+--- a/kernel-open/Kbuild
++++ b/kernel-open/Kbuild
 @@ -77,6 +77,7 @@ $(foreach _module, $(NV_KERNEL_MODULES), \
- 
+
  ccflags-y += -I$(src)/common/inc
  ccflags-y += -I$(src)
 +ccflags-y += -I$(NV_OOT_SOURCES)/include
@@ -76,11 +76,11 @@ index 710570f..9ade365 100644
 +	$(NV_CONFTEST_CMD) $@ full_output
  
  # Perform all sanity checks before generating the conftest headers
- 
-diff --git a/unifiedgpudisp/kernel-open/Makefile b/unifiedgpudisp/kernel-open/Makefile
+
+diff --git a/kernel-open/Makefile b/kernel-open/Makefile
 index 245d91b..ea53d57 100644
---- a/unifiedgpudisp/kernel-open/Makefile
-+++ b/unifiedgpudisp/kernel-open/Makefile
+--- a/kernel-open/Makefile
++++ b/kernel-open/Makefile
 @@ -129,6 +129,7 @@ else
    KBUILD_PARAMS += ARCH=$(ARCH)
    KBUILD_PARAMS += NV_KERNEL_SOURCES=$(KERNEL_SOURCES)
@@ -89,10 +89,10 @@ index 245d91b..ea53d57 100644
    KBUILD_PARAMS += NV_KERNEL_MODULES="$(NV_KERNEL_MODULES)"
    KBUILD_PARAMS += INSTALL_MOD_DIR="$(INSTALL_MOD_DIR)"
    KBUILD_PARAMS += NV_SPECTRE_V2=$(SPECTRE_V2_RETPOLINE)
-diff --git a/unifiedgpudisp/kernel-open/conftest.sh b/unifiedgpudisp/kernel-open/conftest.sh
+diff --git a/kernel-open/conftest.sh b/kernel-open/conftest.sh
 index c4171a0..9c34e18 100755
---- a/unifiedgpudisp/kernel-open/conftest.sh
-+++ b/unifiedgpudisp/kernel-open/conftest.sh
+--- a/kernel-open/conftest.sh
++++ b/kernel-open/conftest.sh
 @@ -11,6 +11,8 @@ ARCH=$2
  SOURCES=$3
  HEADERS=$SOURCES/include

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0005-Fix-unifiedgpudisp-conftest-gcc-14-compatibility-iss.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0005-Fix-unifiedgpudisp-conftest-gcc-14-compatibility-iss.patch
@@ -7,13 +7,13 @@ Upstream-Status: Inappropriate [OE specific]
 
 Signed-off-by: Ilies CHERGUI <ichergui@nvidia.com>
 ---
- unifiedgpudisp/kernel-open/conftest.sh | 4 ++--
+ kernel-open/conftest.sh | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)
 
-diff --git a/unifiedgpudisp/kernel-open/conftest.sh b/unifiedgpudisp/kernel-open/conftest.sh
-index 3f42ff2..12acf19 100755
---- a/unifiedgpudisp/kernel-open/conftest.sh
-+++ b/unifiedgpudisp/kernel-open/conftest.sh
+diff --git a/kernel-open/conftest.sh b/kernel-open/conftest.sh
+index 9c34e18..12acf19 100755
+--- a/kernel-open/conftest.sh
++++ b/kernel-open/conftest.sh
 @@ -106,8 +106,8 @@ build_cflags() {
      ISYSTEM=`$CC -print-file-name=include 2> /dev/null`
      BASE_CFLAGS="-O2 -D__KERNEL__ \

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0006-conftest-work-around-stringify-issue-with.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0006-conftest-work-around-stringify-issue-with.patch
@@ -26,13 +26,13 @@ particular test.
 Upstream-Status: Pending
 Signed-off-by: Matt Madison <matt@madison.systems>
 ---
- nvidia-oot/scripts/conftest/conftest.sh | 1 +
+ scripts/conftest/conftest.sh | 1 +
  1 file changed, 1 insertion(+)
 
-diff --git a/nvidia-oot/scripts/conftest/conftest.sh b/nvidia-oot/scripts/conftest/conftest.sh
+diff --git a/scripts/conftest/conftest.sh b/scripts/conftest/conftest.sh
 index 512b381..cd52a80 100755
---- a/nvidia-oot/scripts/conftest/conftest.sh
-+++ b/nvidia-oot/scripts/conftest/conftest.sh
+--- a/scripts/conftest/conftest.sh
++++ b/scripts/conftest/conftest.sh
 @@ -6478,6 +6478,7 @@ compile_test() {
          __assign_str_has_no_src_arg)
              #

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot_git.bb
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot_git.bb
@@ -39,11 +39,13 @@ PV = "38.4.0+git"
 
 SRC_URI += " \
     file://0001-Makefile-update-for-OE-builds.patch \
-    file://0002-Fix-nvdisplay-modules-builds.patch \
-    file://0003-Fix-nvdisplay-conftest-gcc-14-compatibility-issues.patch \
-    file://0004-Fix-unifiedgpudisp-modules-builds.patch \
-    file://0005-Fix-unifiedgpudisp-conftest-gcc-14-compatibility-iss.patch \
-    file://0006-conftest-work-around-stringify-issue-with.patch \
+    file://0001-Fix-build-warning-on-rtl8852ce-driver.patch;patchdir=nvidia-oot \
+    file://0002-Makefile-Add-OOTSRC-for-nvdisplay-builds.patch \
+    file://0002-Fix-nvdisplay-modules-builds.patch;patchdir=nvdisplay \
+    file://0003-Fix-nvdisplay-conftest-gcc-14-compatibility-issues.patch;patchdir=nvdisplay \
+    file://0004-Fix-unifiedgpudisp-modules-builds.patch;patchdir=unifiedgpudisp \
+    file://0005-Fix-unifiedgpudisp-conftest-gcc-14-compatibility-iss.patch;patchdir=unifiedgpudisp \
+    file://0006-conftest-work-around-stringify-issue-with.patch;patchdir=nvidia-oot \
 "
 
 do_unpack[depends] += "tegra-binaries:do_preconfigure"


### PR DESCRIPTION
When patching nvidia-kernel-oot during normal build quilt is used. When patching nvidia-kernel-oot using 'devtool modify' git is used. For that reason it was not possible to use 'devtool modify' because all patches had their root in the top directory. This patch reworks all patches to only touch top directory or one git sub repo.

Patches 0001-Makefile-update-for-OE-builds.patch and 0002-Fix-nvdisplay-modules-builds.patch has been split to two patches each, one for top Makefile and one for sub directory. Numbering for those has been kept for traceability, meaning two patches with 0001 and two with 0002 prefix.

Other patches that only touched one sub directory has changed path inside and ';patchdir=<path>' added to recipe.