### PR TITLE
libconfig-tegra_1.8.1.bb: fix md5 and sha256sum

### DIFF
--- a/recipes-extended/libconfig/libconfig-tegra_1.8.1.bb
+++ b/recipes-extended/libconfig/libconfig-tegra_1.8.1.bb
@@ -8,8 +8,8 @@ LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://COPYING.LIB;md5=17c8e32f0f72580cc2906b409d46b5ac"
 
 SRC_URI = "https://hyperrealm.github.io/libconfig/dist/libconfig-${PV}.tar.gz"
-SRC_URI[md5sum] = "82563b674c793dee5175f5d52f202688"
-SRC_URI[sha256sum] = "87c6f382994b245f9213be34a2bf19c8ee7d033d7abaa51e88fbb7bad79e2dc6"
+SRC_URI[md5sum] = "400bda5fc247556536688a5370f6f664"
+SRC_URI[sha256sum] = "c73ee3d914ec68c99b61e864832931e9a7112eeabfb449dad217fd83e385cbdf"
 
 PROVIDES = "libconfig"
 


### PR DESCRIPTION
Fixes the following error:
ERROR: libconfig-tegra-1.8.1-r0 do_fetch: Fetcher failure for URL: 'https://hyperrealm.github.io/libconfig/dist/libconfig-1.8.1.tar.gz'. Checksum mismatch! File: '/downloads/libconfig-1.8.1.tar.gz.tmp' has md5 checksum '400bda5fc247556536688a5370f6f664' when '82563b674c793dee5175f5d52f202688' was expected File: '/downloads/libconfig-1.8.1.tar.gz.tmp' has sha256 checksum 'c73ee3d914ec68c99b61e864832931e9a7112eeabfb449dad217fd83e385cbdf' when '87c6f382994b245f9213be34a2bf19c8ee7d033d7abaa51e88fbb7bad79e2dc6' was expected