### PR TITLE
Remove docker from nvidia-container-toolkit RDEPENDS

### DIFF
--- a/external/virtualization-layer/recipes-containers/nvidia-container-toolkit/nvidia-container-toolkit_1.16.2.bb
+++ b/external/virtualization-layer/recipes-containers/nvidia-container-toolkit/nvidia-container-toolkit_1.16.2.bb
@@ -72,7 +72,6 @@ do_install(){
 SYSTEMD_SERVICE:${PN} = "nvidia-container-setup.service"
 RDEPENDS:${PN} = "\
     libnvidia-container-tools \
-    docker \
     nv-tegra-release \
     tegra-configs-container-csv \
     tegra-libraries-nvml \


### PR DESCRIPTION
nvidia-container-toolkit works with any container engine. docker is not a requirement.