### PR TITLE
Fixes for perf and python3-tensorrt

### DIFF
--- a/external/meta-python/recipes-devtools/python3-tensorrt/python3-tensorrt_10.13.3.bb
+++ b/external/meta-python/recipes-devtools/python3-tensorrt/python3-tensorrt_10.13.3.bb
@@ -25,7 +25,8 @@ EXTRA_OECMAKE = "-DTENSORRT_ROOT=${S} -DTENSORRT_LIBPATH=${STAGING_LIBDIR} -DTEN
                  -DCUDA_INCLUDE_DIRS=${CUDA_PATH}/include \
                  -DTARGET=${HOST_ARCH} -DCMAKE_BUILD_TYPE=Release \
                  -DPY_INCLUDE=${STAGING_INCDIR}/${PYTHON_DIR} -DEXT_PATH=${STAGING_INCDIR} \
-                 -DCMAKE_POLICY_VERSION_MINIMUM=3.5 "
+                 -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+                 -DTRT_NVINFER_NAME=nvinfer -DTRT_ONNXPARSER_NAME=nvonnxparser "
 
 CXXFLAGS += "${CUDA_CXXFLAGS}"
 
@@ -62,4 +63,4 @@ do_install() {
     setuptools3_do_install
 }
 
-RDEPENDS:${PN} = "python3-ctypes python3-numpy"
+RDEPENDS:${PN} = "python3-ctypes python3-numpy tensorrt-plugins"

--- a/recipes-kernel/linux/linux-noble-nvidia-tegra-6.8/0002-perf-build-Setup-PKG_CONFIG_LIBDIR-for-cross-compila.patch
+++ b/recipes-kernel/linux/linux-noble-nvidia-tegra-6.8/0002-perf-build-Setup-PKG_CONFIG_LIBDIR-for-cross-compila.patch
@@ -1,0 +1,104 @@
+From 440cf77625e300e683ca0edc39fbc4b6f3175feb Mon Sep 17 00:00:00 2001
+From: Leo Yan <leo.yan@arm.com>
+Date: Wed, 17 Jul 2024 09:22:06 +0100
+Subject: [PATCH] perf: build: Setup PKG_CONFIG_LIBDIR for cross compilation
+
+On recent Linux distros like Ubuntu Noble and Debian Bookworm, the
+'pkg-config-aarch64-linux-gnu' package is missing. As a result, the
+aarch64-linux-gnu-pkg-config command is not available, which causes
+build failures.
+
+When a build passes the environment variables PKG_CONFIG_LIBDIR or
+PKG_CONFIG_PATH, like a user uses make command or a build system
+(like Yocto, Buildroot, etc) prepares the variables and passes to the
+Perf's Makefile, the commit keeps these variables for package
+configuration. Otherwise, this commit sets the PKG_CONFIG_LIBDIR
+variable to use the Multiarch libs for the cross compilation.
+
+Upstream-Status: Backport [440cf77625e300e683ca0edc39fbc4b6f3175feb]
+
+Signed-off-by: Leo Yan <leo.yan@arm.com>
+Tested-by: Ian Rogers <irogers@google.com>
+Cc: amadio@gentoo.org
+Cc: Thomas Richter <tmricht@linux.ibm.com>
+Link: https://lore.kernel.org/r/20240717082211.524826-2-leo.yan@arm.com
+Signed-off-by: Namhyung Kim <namhyung@kernel.org>
+---
+ tools/build/feature/Makefile | 25 ++++++++++++++++++++++++-
+ tools/perf/Makefile.perf     | 27 ++++++++++++++++++++++++++-
+ 2 files changed, 50 insertions(+), 2 deletions(-)
+
+diff --git a/tools/build/feature/Makefile b/tools/build/feature/Makefile
+index ed54cef450f5..dff65d03d30d 100644
+--- a/tools/build/feature/Makefile
++++ b/tools/build/feature/Makefile
+@@ -82,7 +82,30 @@ FILES=                                          \
+
+ FILES := $(addprefix $(OUTPUT),$(FILES))
+
+-PKG_CONFIG ?= $(CROSS_COMPILE)pkg-config
++# Some distros provide the command $(CROSS_COMPILE)pkg-config for
++# searching packges installed with Multiarch. Use it for cross
++# compilation if it is existed.
++ifneq (, $(shell which $(CROSS_COMPILE)pkg-config))
++  PKG_CONFIG ?= $(CROSS_COMPILE)pkg-config
++else
++  PKG_CONFIG ?= pkg-config
++
++  # PKG_CONFIG_PATH or PKG_CONFIG_LIBDIR, alongside PKG_CONFIG_SYSROOT_DIR
++  # for modified system root, are required for the cross compilation.
++  # If these PKG_CONFIG environment variables are not set, Multiarch library
++  # paths are used instead.
++  ifdef CROSS_COMPILE
++    ifeq ($(PKG_CONFIG_LIBDIR)$(PKG_CONFIG_PATH)$(PKG_CONFIG_SYSROOT_DIR),)
++      CROSS_ARCH = $(shell $(CC) -dumpmachine)
++      PKG_CONFIG_LIBDIR := /usr/local/$(CROSS_ARCH)/lib/pkgconfig/
++      PKG_CONFIG_LIBDIR := $(PKG_CONFIG_LIBDIR):/usr/local/lib/$(CROSS_ARCH)/pkgconfig/
++      PKG_CONFIG_LIBDIR := $(PKG_CONFIG_LIBDIR):/usr/lib/$(CROSS_ARCH)/pkgconfig/
++      PKG_CONFIG_LIBDIR := $(PKG_CONFIG_LIBDIR):/usr/local/share/pkgconfig/
++      PKG_CONFIG_LIBDIR := $(PKG_CONFIG_LIBDIR):/usr/share/pkgconfig/
++      export PKG_CONFIG_LIBDIR
++    endif
++  endif
++endif
+
+ all: $(FILES)
+
+diff --git a/tools/perf/Makefile.perf b/tools/perf/Makefile.perf
+index 175e4c7898f0..f8148db5fc38 100644
+--- a/tools/perf/Makefile.perf
++++ b/tools/perf/Makefile.perf
+@@ -193,7 +193,32 @@ HOSTLD  ?= ld
+ HOSTAR  ?= ar
+ CLANG   ?= clang
+
+-PKG_CONFIG = $(CROSS_COMPILE)pkg-config
++# Some distros provide the command $(CROSS_COMPILE)pkg-config for
++# searching packges installed with Multiarch. Use it for cross
++# compilation if it is existed.
++ifneq (, $(shell which $(CROSS_COMPILE)pkg-config))
++  PKG_CONFIG ?= $(CROSS_COMPILE)pkg-config
++else
++  PKG_CONFIG ?= pkg-config
++
++  # PKG_CONFIG_PATH or PKG_CONFIG_LIBDIR, alongside PKG_CONFIG_SYSROOT_DIR
++  # for modified system root, is required for the cross compilation.
++  # If these PKG_CONFIG environment variables are not set, Multiarch library
++  # paths are used instead.
++  ifdef CROSS_COMPILE
++    ifeq ($(PKG_CONFIG_LIBDIR)$(PKG_CONFIG_PATH)$(PKG_CONFIG_SYSROOT_DIR),)
++      CROSS_ARCH = $(shell $(CC) -dumpmachine)
++      PKG_CONFIG_LIBDIR := /usr/local/$(CROSS_ARCH)/lib/pkgconfig/
++      PKG_CONFIG_LIBDIR := $(PKG_CONFIG_LIBDIR):/usr/local/lib/$(CROSS_ARCH)/pkgconfig/
++      PKG_CONFIG_LIBDIR := $(PKG_CONFIG_LIBDIR):/usr/lib/$(CROSS_ARCH)/pkgconfig/
++      PKG_CONFIG_LIBDIR := $(PKG_CONFIG_LIBDIR):/usr/local/share/pkgconfig/
++      PKG_CONFIG_LIBDIR := $(PKG_CONFIG_LIBDIR):/usr/share/pkgconfig/
++      export PKG_CONFIG_LIBDIR
++      $(warning Missing PKG_CONFIG_LIBDIR, PKG_CONFIG_PATH and PKG_CONFIG_SYSROOT_DIR for cross compilation,)
++      $(warning set PKG_CONFIG_LIBDIR for using Multiarch libs.)
++    endif
++  endif
++endif
+
+ RM      = rm -f
+ LN      = ln -f

--- a/recipes-kernel/linux/linux-noble-nvidia-tegra-6.8/0003-perf-metricgroup-Constify-variables-storing-the-resu.patch
+++ b/recipes-kernel/linux/linux-noble-nvidia-tegra-6.8/0003-perf-metricgroup-Constify-variables-storing-the-resu.patch
@@ -1,0 +1,42 @@
+From b42868624c7d00206f77d19a6fbfea73a44ff6f2 Mon Sep 17 00:00:00 2001
+From: Arnaldo Carvalho de Melo <acme@redhat.com>
+Date: Tue, 27 Jan 2026 01:15:47 -0300
+Subject: [PATCH 02/12] perf metricgroup: Constify variables storing the result
+ of strchr() on const tables
+
+As newer glibcs will propagate the const attribute of the searched table
+to its return.
+
+Upstream-Status: Backport [b42868624c7d00206f77d19a6fbfea73a44ff6f2]
+
+Signed-off-by: Arnaldo Carvalho de Melo <acme@redhat.com>
+---
+ tools/perf/util/metricgroup.c | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/tools/perf/util/metricgroup.c b/tools/perf/util/metricgroup.c
+index 25c75fdbfc525..40a1e14de4189 100644
+--- a/tools/perf/util/metricgroup.c
++++ b/tools/perf/util/metricgroup.c
+@@ -367,7 +367,7 @@ static int setup_metric_events(const char *pmu, struct hashmap *ids,
+ static bool match_metric_or_groups(const char *metric_or_groups, const char *sought)
+ {
+ 	int len;
+-	char *m;
++	const char *m;
+
+ 	if (!sought)
+ 		return false;
+@@ -450,11 +450,10 @@ static const char *code_characters = ",-=@";
+
+ static int encode_metric_id(struct strbuf *sb, const char *x)
+ {
+-	char *c;
+ 	int ret = 0;
+
+ 	for (; *x; x++) {
+-		c = strchr(code_characters, *x);
++		const char *c = strchr(code_characters, *x);
+ 		if (c) {
+ 			ret = strbuf_addch(sb, '!');
+ 			if (ret)

--- a/recipes-kernel/linux/linux-noble-nvidia-tegra-6.8/0004-perf-strlist-Don-t-write-to-const-memory.patch
+++ b/recipes-kernel/linux/linux-noble-nvidia-tegra-6.8/0004-perf-strlist-Don-t-write-to-const-memory.patch
@@ -1,0 +1,50 @@
+From 678ed6b707e4b2db250f255d2f959322896dae65 Mon Sep 17 00:00:00 2001
+From: Arnaldo Carvalho de Melo <acme@redhat.com>
+Date: Tue, 27 Jan 2026 02:03:01 -0300
+Subject: [PATCH 03/12] perf strlist: Don't write to const memory
+
+Do a strdup to the list string and parse from it, free at the end.
+
+This is to deal with newer glibcs const-correctness.
+
+Upstream-Status: Backport [678ed6b707e4b2db250f255d2f959322896dae65]
+
+Signed-off-by: Arnaldo Carvalho de Melo <acme@redhat.com>
+---
+ tools/perf/util/strlist.c | 12 ++++++++----
+ 1 file changed, 8 insertions(+), 4 deletions(-)
+
+diff --git a/tools/perf/util/strlist.c b/tools/perf/util/strlist.c
+index 8a868cbeffae2..98883672fcf47 100644
+--- a/tools/perf/util/strlist.c
++++ b/tools/perf/util/strlist.c
+@@ -139,21 +139,25 @@ static int strlist__parse_list_entry(struct strlist *slist, const char *s,
+ 	return err;
+ }
+
+-static int strlist__parse_list(struct strlist *slist, const char *s, const char *subst_dir)
++static int strlist__parse_list(struct strlist *slist, const char *list, const char *subst_dir)
+ {
+-	char *sep;
++	char *sep, *s = strdup(list), *sdup = s;
+ 	int err;
+
++	if (s == NULL)
++		return -ENOMEM;
++
+ 	while ((sep = strchr(s, ',')) != NULL) {
+ 		*sep = '\0';
+ 		err = strlist__parse_list_entry(slist, s, subst_dir);
+-		*sep = ',';
+ 		if (err != 0)
+ 			return err;
+ 		s = sep + 1;
+ 	}
+
+-	return *s ? strlist__parse_list_entry(slist, s, subst_dir) : 0;
++	err = *s ? strlist__parse_list_entry(slist, s, subst_dir) : 0;
++	free(sdup);
++	return err;
+ }
+
+ struct strlist *strlist__new(const char *list, const struct strlist_config *config)

--- a/recipes-kernel/linux/linux-noble-nvidia-tegra-6.8/0005-perf-session-Don-t-write-to-memory-pointed-to-a-cons.patch
+++ b/recipes-kernel/linux/linux-noble-nvidia-tegra-6.8/0005-perf-session-Don-t-write-to-memory-pointed-to-a-cons.patch
@@ -1,0 +1,47 @@
+From f1321cce848c558fde4c0c6bcd5e53f3cefd3af2 Mon Sep 17 00:00:00 2001
+From: Arnaldo Carvalho de Melo <acme@redhat.com>
+Date: Tue, 27 Jan 2026 02:09:37 -0300
+Subject: [PATCH 04/12] perf session: Don't write to memory pointed to a const
+ pointer
+
+Since it is freshly allocated just attribute it to a non-const pointer
+and then change it via that pointer.
+
+That way we avoid const-correctness warnings in recent glibc versions.
+
+Upstream-Status: Backport [f1321cce848c558fde4c0c6bcd5e53f3cefd3af2]
+
+Signed-off-by: Arnaldo Carvalho de Melo <acme@redhat.com>
+---
+ tools/perf/util/session.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/tools/perf/util/session.c b/tools/perf/util/session.c
+index ae62d5c9889fe..d0053618f5404 100644
+--- a/tools/perf/util/session.c
++++ b/tools/perf/util/session.c
+@@ -2676,7 +2676,7 @@ bool perf_session__has_switch_events(struct perf_session *session)
+
+ int map__set_kallsyms_ref_reloc_sym(struct map *map, const char *symbol_name, u64 addr)
+ {
+-	char *bracket;
++	char *bracket, *name;
+ 	struct ref_reloc_sym *ref;
+ 	struct kmap *kmap;
+
+@@ -2684,13 +2684,13 @@ int map__set_kallsyms_ref_reloc_sym(struct map *map, const char *symbol_name, u6
+ 	if (ref == NULL)
+ 		return -ENOMEM;
+
+-	ref->name = strdup(symbol_name);
++	ref->name = name = strdup(symbol_name);
+ 	if (ref->name == NULL) {
+ 		free(ref);
+ 		return -ENOMEM;
+ 	}
+
+-	bracket = strchr(ref->name, ']');
++	bracket = strchr(name, ']');
+ 	if (bracket)
+ 		*bracket = '\0';
+

--- a/recipes-kernel/linux/linux-noble-nvidia-tegra-6.8/0006-perf-trace-event-Constify-variables-storing-the-resu.patch
+++ b/recipes-kernel/linux/linux-noble-nvidia-tegra-6.8/0006-perf-trace-event-Constify-variables-storing-the-resu.patch
@@ -1,0 +1,29 @@
+From 97b81df7225830c4db3c17ed1235d2f3eb613d3d Mon Sep 17 00:00:00 2001
+From: Arnaldo Carvalho de Melo <acme@redhat.com>
+Date: Tue, 27 Jan 2026 01:15:47 -0300
+Subject: [PATCH 07/12] perf trace-event: Constify variables storing the result
+ of strchr() on const tables
+
+As newer glibcs will propagate the const attribute of the searched table
+to its return.
+
+Upstream-Status: Backport [97b81df7225830c4db3c17ed1235d2f3eb613d3d]
+
+Signed-off-by: Arnaldo Carvalho de Melo <acme@redhat.com>
+---
+ tools/perf/util/trace-event-info.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/perf/util/trace-event-info.c b/tools/perf/util/trace-event-info.c
+index c8755679281eb..45774722f2492 100644
+--- a/tools/perf/util/trace-event-info.c
++++ b/tools/perf/util/trace-event-info.c
+@@ -482,7 +482,7 @@ char *tracepoint_id_to_name(u64 config)
+ static struct tracepoint_path *tracepoint_name_to_path(const char *name)
+ {
+ 	struct tracepoint_path *path = zalloc(sizeof(*path));
+-	char *str = strchr(name, ':');
++	const char *str = strchr(name, ':');
+
+ 	if (path == NULL || str == NULL) {
+ 		free(path);

--- a/recipes-kernel/linux/linux-noble-nvidia-tegra-6.8/0007-perf-units-Constify-variables-storing-the-result-of-.patch
+++ b/recipes-kernel/linux/linux-noble-nvidia-tegra-6.8/0007-perf-units-Constify-variables-storing-the-result-of-.patch
@@ -1,0 +1,29 @@
+From 0e14cb3b24f8f301cf6490a4493afc98321ed5bb Mon Sep 17 00:00:00 2001
+From: Arnaldo Carvalho de Melo <acme@redhat.com>
+Date: Tue, 27 Jan 2026 01:15:47 -0300
+Subject: [PATCH 08/12] perf units: Constify variables storing the result of
+ strchr() on const tables
+
+As newer glibcs will propagate the const attribute of the searched table
+to its return.
+
+Upstream-Status: Backport [0e14cb3b24f8f301cf6490a4493afc98321ed5bb]
+
+Signed-off-by: Arnaldo Carvalho de Melo <acme@redhat.com>
+---
+ tools/perf/util/units.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/perf/util/units.c b/tools/perf/util/units.c
+index 4c6a86e1cb54b..0bbacf5a29aaf 100644
+--- a/tools/perf/util/units.c
++++ b/tools/perf/util/units.c
+@@ -12,7 +12,7 @@ unsigned long parse_tag_value(const char *str, struct parse_tag *tags)
+ 	struct parse_tag *i = tags;
+
+ 	while (i->tag) {
+-		char *s = strchr(str, i->tag);
++		const char *s = strchr(str, i->tag);
+
+ 		if (s) {
+ 			unsigned long int value;

--- a/recipes-kernel/linux/linux-noble-nvidia-tegra-6.8/0008-perf-time-utils-Constify-variables-storing-the-resul.patch
+++ b/recipes-kernel/linux/linux-noble-nvidia-tegra-6.8/0008-perf-time-utils-Constify-variables-storing-the-resul.patch
@@ -1,0 +1,38 @@
+From 21c0bc9144834e39762dd6fddbb255ebb80cf079 Mon Sep 17 00:00:00 2001
+From: Arnaldo Carvalho de Melo <acme@redhat.com>
+Date: Tue, 27 Jan 2026 01:15:47 -0300
+Subject: [PATCH 09/12] perf time-utils: Constify variables storing the result
+ of strchr() on const tables
+
+As newer glibcs will propagate the const attribute of the searched table
+to its return.
+
+Upstream-Status: Backport [21c0bc9144834e39762dd6fddbb255ebb80cf079]
+
+Signed-off-by: Arnaldo Carvalho de Melo <acme@redhat.com>
+---
+ tools/perf/util/time-utils.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tools/perf/util/time-utils.c b/tools/perf/util/time-utils.c
+index 1b91ccd4d5234..d43c4577d7ebc 100644
+--- a/tools/perf/util/time-utils.c
++++ b/tools/perf/util/time-utils.c
+@@ -325,7 +325,7 @@ static int percent_comma_split(struct perf_time_interval *ptime_buf, int num,
+ }
+
+ static int one_percent_convert(struct perf_time_interval *ptime_buf,
+-			       const char *ostr, u64 start, u64 end, char *c)
++			       const char *ostr, u64 start, u64 end, const char *c)
+ {
+ 	char *str;
+ 	int len = strlen(ostr), ret;
+@@ -358,7 +358,7 @@ static int one_percent_convert(struct perf_time_interval *ptime_buf,
+ int perf_time__percent_parse_str(struct perf_time_interval *ptime_buf, int num,
+ 				 const char *ostr, u64 start, u64 end)
+ {
+-	char *c;
++	const char *c;
+
+ 	/*
+ 	 * ostr example:

--- a/recipes-kernel/linux/linux-noble-nvidia-tegra-6.8/0009-perf-demangle-java-Constify-variables-storing-the-re.patch
+++ b/recipes-kernel/linux/linux-noble-nvidia-tegra-6.8/0009-perf-demangle-java-Constify-variables-storing-the-re.patch
@@ -1,0 +1,29 @@
+From 79bba3a1834e7ba6c437674582cc9f3ae6fb638c Mon Sep 17 00:00:00 2001
+From: Arnaldo Carvalho de Melo <acme@redhat.com>
+Date: Tue, 27 Jan 2026 01:15:47 -0300
+Subject: [PATCH 10/12] perf demangle-java: Constify variables storing the
+ result of strchr() on const tables
+
+As newer glibcs will propagate the const attribute of the searched table
+to its return.
+
+Upstream-Status: Backport [79bba3a1834e7ba6c437674582cc9f3ae6fb638c]
+
+Signed-off-by: Arnaldo Carvalho de Melo <acme@redhat.com>
+---
+ tools/perf/util/demangle-java.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/perf/util/demangle-java.c b/tools/perf/util/demangle-java.c
+index ddf33d58bcd35..c3cb327ed5623 100644
+--- a/tools/perf/util/demangle-java.c
++++ b/tools/perf/util/demangle-java.c
+@@ -158,7 +158,7 @@ char *
+ java_demangle_sym(const char *str, int flags)
+ {
+ 	char *buf, *ptr;
+-	char *p;
++	const char *p;
+ 	size_t len, l1 = 0;
+
+ 	if (!str)

--- a/recipes-kernel/linux/linux-noble-nvidia-tegra-6.8/0010-perf-bpf-event-Constify-variables-storing-the-result.patch
+++ b/recipes-kernel/linux/linux-noble-nvidia-tegra-6.8/0010-perf-bpf-event-Constify-variables-storing-the-result.patch
@@ -1,0 +1,30 @@
+From 8bf093acb3f1f07d846c86e32308f9f9954ed579 Mon Sep 17 00:00:00 2001
+From: Arnaldo Carvalho de Melo <acme@redhat.com>
+Date: Tue, 27 Jan 2026 01:15:47 -0300
+Subject: [PATCH 11/12] perf bpf-event: Constify variables storing the result
+ of strchr() on const tables
+
+As newer glibcs will propagate the const attribute of the searched table
+to its return.
+
+Upstream-Status: Backport [8bf093acb3f1f07d846c86e32308f9f9954ed579]
+
+Signed-off-by: Arnaldo Carvalho de Melo <acme@redhat.com>
+---
+ tools/perf/util/bpf-event.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/tools/perf/util/bpf-event.c b/tools/perf/util/bpf-event.c
+index 2e6da3ad0a4f9..67e7786bb878b 100644
+--- a/tools/perf/util/bpf-event.c
++++ b/tools/perf/util/bpf-event.c
+@@ -733,7 +733,8 @@ kallsyms_process_symbol(void *data, const char *_name,
+ 			char type __maybe_unused, u64 start)
+ {
+ 	char disp[KSYM_NAME_LEN];
+-	char *module, *name;
++	const char *module;
++	char *name;
+ 	unsigned long id;
+ 	int err = 0;
+

--- a/recipes-kernel/linux/linux-noble-nvidia-tegra-6.8/0011-perf-jitdump-Constify-variables-storing-the-result-o.patch
+++ b/recipes-kernel/linux/linux-noble-nvidia-tegra-6.8/0011-perf-jitdump-Constify-variables-storing-the-result-o.patch
@@ -1,0 +1,29 @@
+From 68abacb0686651dd3f0bbce2fa94b438afeb2fc4 Mon Sep 17 00:00:00 2001
+From: Arnaldo Carvalho de Melo <acme@redhat.com>
+Date: Tue, 27 Jan 2026 01:15:47 -0300
+Subject: [PATCH 12/12] perf jitdump: Constify variables storing the result of
+ strchr() on const tables
+
+As newer glibcs will propagate the const attribute of the searched table
+to its return.
+
+Upstream-Status: Backport [68abacb0686651dd3f0bbce2fa94b438afeb2fc4]
+
+Signed-off-by: Arnaldo Carvalho de Melo <acme@redhat.com>
+---
+ tools/perf/util/jitdump.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/perf/util/jitdump.c b/tools/perf/util/jitdump.c
+index d4fe35f9d9a5f..e0ce8b9047298 100644
+--- a/tools/perf/util/jitdump.c
++++ b/tools/perf/util/jitdump.c
+@@ -758,7 +758,7 @@ jit_inject(struct jit_buf_desc *jd, const char *path)
+ static int
+ jit_detect(const char *mmap_name, pid_t pid, struct nsinfo *nsi, bool *in_pidns)
+  {
+-	char *p;
++	const char *p;
+ 	char *end = NULL;
+ 	pid_t pid2;
+

--- a/recipes-kernel/linux/linux-noble-nvidia-tegra-6.8/0012-perf-tools-Use-const-for-variables-receiving-str-str.patch
+++ b/recipes-kernel/linux/linux-noble-nvidia-tegra-6.8/0012-perf-tools-Use-const-for-variables-receiving-str-str.patch
@@ -1,0 +1,52 @@
+From 029fd0083895c505caaafe6f3100976b17df9c73 Mon Sep 17 00:00:00 2001
+From: Arnaldo Carvalho de Melo <acme@kernel.org>
+Date: Thu, 11 Dec 2025 19:17:55 -0300
+Subject: [PATCH] perf tools: Use const for variables receiving
+ str{str,r?chr}() returns
+
+Newer glibc versions return const char for str{str,chr}() where the
+haystack/s is const so to avoid warnings like these on fedora 44 change
+some variables to const:
+
+  36     8.17 fedora:44                     : FAIL gcc version 15.2.1 20251111 (Red Hat 15.2.1-4) (GCC)
+    libbpf.c: In function 'kallsyms_cb':
+    libbpf.c:8489:13: error: assignment discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
+     8489 |         res = strstr(sym_name, ".llvm.");
+
+Upstream-Status: Backport [45718bce7daf39c618188b70a52644bb5a2f968a]
+
+Reviewed-by: Ian Rogers <irogers@google.com>
+Link: https://lore.kernel.org/r/20251211221756.96294-4-acme@kernel.org
+Signed-off-by: Arnaldo Carvalho de Melo <acme@redhat.com>
+---
+ tools/perf/jvmti/libjvmti.c | 2 +-
+ tools/perf/util/evlist.c    | 3 ++-
+ 2 files changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/tools/perf/jvmti/libjvmti.c b/tools/perf/jvmti/libjvmti.c
+index fcca275e5bf9..d6b04d0fd35a 100644
+--- a/tools/perf/jvmti/libjvmti.c
++++ b/tools/perf/jvmti/libjvmti.c
+@@ -142,7 +142,7 @@ copy_class_filename(const char * class_sign, const char * file_name, char * resu
+ 	*/
+ 	if (*class_sign == 'L') {
+ 		int j, i = 0;
+-		char *p = strrchr(class_sign, '/');
++		const char *p = strrchr(class_sign, '/');
+ 		if (p) {
+ 			/* drop the 'L' prefix and copy up to the final '/' */
+ 			for (i = 0; i < (p - class_sign); i++)
+diff --git a/tools/perf/util/evlist.c b/tools/perf/util/evlist.c
+index a234fbf85df1..dc035c40b4cd 100644
+--- a/tools/perf/util/evlist.c
++++ b/tools/perf/util/evlist.c
+@@ -1924,7 +1924,8 @@ static int evlist__parse_control_fifo(const char *str, int *ctl_fd, int *ctl_fd_
+ 
+ int evlist__parse_control(const char *str, int *ctl_fd, int *ctl_fd_ack, bool *ctl_fd_close)
+ {
+-	char *comma = NULL, *endptr = NULL;
++	const char *comma = NULL;
++	char *endptr = NULL;
+ 
+ 	*ctl_fd_close = false;
+ 

--- a/recipes-kernel/linux/linux-noble-nvidia-tegra-6.8/0013-perf-python-Stop-using-deprecated-PyUnicode_AsString.patch
+++ b/recipes-kernel/linux/linux-noble-nvidia-tegra-6.8/0013-perf-python-Stop-using-deprecated-PyUnicode_AsString.patch
@@ -1,0 +1,67 @@
+From 6606a63d414d0f7dc826b2f8ba823b0d311f0c26 Mon Sep 17 00:00:00 2001
+From: Arnaldo Carvalho de Melo <acme@kernel.org>
+Date: Wed, 30 Jul 2025 10:34:20 -0300
+Subject: [PATCH] perf python: Stop using deprecated PyUnicode_AsString()
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+As noticed while building for Fedora 43:
+
+    GEN     /tmp/build/perf/python/perf.cpython-314-x86_64-linux-gnu.so
+  /git/perf-6.16.0-rc3/tools/perf/util/python.c: In function ‘get_tracepoint_field’:
+  /git/perf-6.16.0-rc3/tools/perf/util/python.c:340:9: error: ‘_PyUnicode_AsString’ is deprecated [-Werror=deprecated-declarations]
+    340 |         const char *str = _PyUnicode_AsString(PyObject_Str(attr_name));
+        |         ^~~~~
+  In file included from /usr/include/python3.14/unicodeobject.h:1022,
+                   from /usr/include/python3.14/Python.h:89,
+                   from /git/perf-6.16.0-rc3/tools/perf/util/python.c:2:
+  /usr/include/python3.14/cpython/unicodeobject.h:648:1: note: declared here
+    648 | _PyUnicode_AsString(PyObject *unicode)
+        | ^~~~~~~~~~~~~~~~~~~
+  cc1: all warnings being treated as errors
+  error: command '/usr/bin/gcc' failed with exit code 1
+
+Use PyUnicode_AsUTF8() instead and also check if PyObject_Str() fails
+before doing so.
+
+Upstream-Status: Backport [59edbec7a5c70af6c0058e32eb3750bfb8928d7b]
+
+Signed-off-by: Arnaldo Carvalho de Melo <acme@redhat.com>
+Link: https://lore.kernel.org/r/aIofXNK8QLtLIaI3@x1
+Signed-off-by: Namhyung Kim <namhyung@kernel.org>
+---
+ tools/perf/util/python.c | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/tools/perf/util/python.c b/tools/perf/util/python.c
+index ae4b2cd2e1e9..8774c6019172 100644
+--- a/tools/perf/util/python.c
++++ b/tools/perf/util/python.c
+@@ -524,7 +524,6 @@ tracepoint_field(struct pyrf_event *pe, struct tep_format_field *field)
+ static PyObject*
+ get_tracepoint_field(struct pyrf_event *pevent, PyObject *attr_name)
+ {
+-	const char *str = _PyUnicode_AsString(PyObject_Str(attr_name));
+ 	struct evsel *evsel = pevent->evsel;
+ 	struct tep_format_field *field;
+
+@@ -538,7 +537,18 @@ get_tracepoint_field(struct pyrf_event *pevent, PyObject *attr_name)
+ 		evsel->tp_format = tp_format;
+ 	}
+
++	PyObject *obj = PyObject_Str(attr_name);
++	if (obj == NULL)
++		return NULL;
++
++	const char *str = PyUnicode_AsUTF8(obj);
++	if (str == NULL) {
++		Py_DECREF(obj);
++		return NULL;
++	}
++
+ 	field = tep_find_any_field(evsel->tp_format, str);
++	Py_DECREF(obj);
+ 	if (!field)
+ 		return NULL;
+

--- a/recipes-kernel/linux/linux-noble-nvidia-tegra-6.8/0014-perf-units-Fix-insufficient-array-space.patch
+++ b/recipes-kernel/linux/linux-noble-nvidia-tegra-6.8/0014-perf-units-Fix-insufficient-array-space.patch
@@ -1,0 +1,40 @@
+From cf67629f7f637fb988228abdb3aae46d0c1748fe Mon Sep 17 00:00:00 2001
+From: Arnaldo Carvalho de Melo <acme@redhat.com>
+Date: Mon, 10 Mar 2025 16:45:32 -0300
+Subject: [PATCH] perf units: Fix insufficient array space
+
+No need to specify the array size, let the compiler figure that out.
+
+This addresses this compiler warning that was noticed while build
+testing on fedora rawhide:
+
+  31    15.81 fedora:rawhide                : FAIL gcc version 15.0.1 20250225 (Red Hat 15.0.1-0) (GCC)
+    util/units.c: In function 'unit_number__scnprintf':
+    util/units.c:67:24: error: initializer-string for array of 'char' is too long [-Werror=unterminated-string-initialization]
+       67 |         char unit[4] = "BKMG";
+          |                        ^~~~~~
+    cc1: all warnings being treated as errors
+
+Upstream-Status: Backport [cf67629f7f637fb988228abdb3aae46d0c1748fe]
+
+Fixes: 9808143ba2e54818 ("perf tools: Add unit_number__scnprintf function")
+Signed-off-by: Arnaldo Carvalho de Melo <acme@redhat.com>
+Link: https://lore.kernel.org/r/20250310194534.265487-3-acme@kernel.org
+Signed-off-by: Namhyung Kim <namhyung@kernel.org>
+---
+ tools/perf/util/units.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/perf/util/units.c b/tools/perf/util/units.c
+index 32c39cfe209b3..4c6a86e1cb54b 100644
+--- a/tools/perf/util/units.c
++++ b/tools/perf/util/units.c
+@@ -64,7 +64,7 @@ unsigned long convert_unit(unsigned long value, char *unit)
+
+ int unit_number__scnprintf(char *buf, size_t size, u64 n)
+ {
+-	char unit[4] = "BKMG";
++	char unit[] = "BKMG";
+ 	int i = 0;
+
+ 	while (((n / 1024) > 1) && (i < 3)) {

--- a/recipes-kernel/linux/linux-noble-nvidia-tegra-6.8/0015-libbpf-Fix-Wdiscarded-qualifiers-under-C23.patch
+++ b/recipes-kernel/linux/linux-noble-nvidia-tegra-6.8/0015-libbpf-Fix-Wdiscarded-qualifiers-under-C23.patch
@@ -1,0 +1,40 @@
+From c60ecbdbf333aef5f5dc387c4bafe5f9968faffe Mon Sep 17 00:00:00 2001
+From: Mikhail Gavrilov <mikhail.v.gavrilov@gmail.com>
+Date: Sat, 6 Dec 2025 14:28:25 +0500
+Subject: [PATCH] libbpf: Fix -Wdiscarded-qualifiers under C23
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+glibc ≥ 2.42 (GCC 15) defaults to -std=gnu23, which promotes
+-Wdiscarded-qualifiers to an error.
+
+In C23, strstr() and strchr() return "const char *".
+
+Change variable types to const char * where the pointers are never
+modified (res, sym_sfx, next_path).
+
+Upstream-Status: Backport [d70f79fef65810faf64dbae1f3a1b5623cdb2345]
+
+Suggested-by: Florian Weimer <fweimer@redhat.com>
+Suggested-by: Andrii Nakryiko <andrii@kernel.org>
+Signed-off-by: Mikhail Gavrilov <mikhail.v.gavrilov@gmail.com>
+Link: https://lore.kernel.org/r/20251206092825.1471385-1-mikhail.v.gavrilov@gmail.com
+Signed-off-by: Alexei Starovoitov <ast@kernel.org>
+---
+ tools/lib/bpf/libbpf.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/lib/bpf/libbpf.c b/tools/lib/bpf/libbpf.c
+index 554e93189c7c..9092d396f147 100644
+--- a/tools/lib/bpf/libbpf.c
++++ b/tools/lib/bpf/libbpf.c
+@@ -11811,7 +11811,7 @@ static int resolve_full_path(const char *file, char *result, size_t result_sz)
+ 		if (!search_paths[i])
+ 			continue;
+ 		for (s = search_paths[i]; s != NULL; s = strchr(s, ':')) {
+-			char *next_path;
++			const char *next_path;
+ 			int seg_len;
+ 
+ 			if (s[0] == ':')

--- a/recipes-kernel/linux/linux-noble-nvidia-tegra.inc
+++ b/recipes-kernel/linux/linux-noble-nvidia-tegra.inc
@@ -27,6 +27,20 @@ SRC_REPO = "gitlab.com/nvidia/nv-tegra/3rdparty/canonical/linux-noble.git;protoc
 KERNEL_REPO = "${SRC_REPO}"
 SRC_URI = "git://${KERNEL_REPO};name=machine;branch=${KBRANCH} \
     file://0001-tty-vt-conmakehash-remove-non-portable-code-printing.patch \
+    file://0002-perf-build-Setup-PKG_CONFIG_LIBDIR-for-cross-compila.patch \
+    file://0003-perf-metricgroup-Constify-variables-storing-the-resu.patch \
+    file://0004-perf-strlist-Don-t-write-to-const-memory.patch \
+    file://0005-perf-session-Don-t-write-to-memory-pointed-to-a-cons.patch \
+    file://0006-perf-trace-event-Constify-variables-storing-the-resu.patch \
+    file://0007-perf-units-Constify-variables-storing-the-result-of-.patch \
+    file://0008-perf-time-utils-Constify-variables-storing-the-resul.patch \
+    file://0009-perf-demangle-java-Constify-variables-storing-the-re.patch \
+    file://0010-perf-bpf-event-Constify-variables-storing-the-result.patch \
+    file://0011-perf-jitdump-Constify-variables-storing-the-result-o.patch \
+    file://0012-perf-tools-Use-const-for-variables-receiving-str-str.patch \
+    file://0013-perf-python-Stop-using-deprecated-PyUnicode_AsString.patch \
+    file://0014-perf-units-Fix-insufficient-array-space.patch \
+    file://0015-libbpf-Fix-Wdiscarded-qualifiers-under-C23.patch \
     ${@'file://localversion_auto.cfg' if d.getVar('SCMVERSION') == 'y' else ''} \
     ${@'file://disable-fw-user-helper.cfg' if d.getVar('KERNEL_DISABLE_FW_USER_HELPER') == 'y' else ''} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'file://systemd.cfg', '', d)} \


### PR DESCRIPTION
perf failed to build on updated stack with newer compiler tools. Fixed by backporting patches from upstream kernel.

Fixed failure on using python3-tensorrt on target.