### PR TITLE
linux-firmware_%.bbappend: Fix Bluetooth

### DIFF
--- a/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -1,0 +1,14 @@
+do_install::append:tegra() {
+    install -d ${D}${nonarch_base_libdir}/firmware
+    ln -s rtl_bt/rtl8822cu_fw.bin ${D}${nonarch_base_libdir}/firmware/rtl8822cu_fw
+    ln -s rtl_bt/rtl8822cu_config.bin ${D}${nonarch_base_libdir}/firmware/rtl8822cu_config
+}
+
+FILES:${PN}-rtl8822:append:tegra = " \
+    ${nonarch_base_libdir}/firmware/rtl8822cu_config \
+    ${nonarch_base_libdir}/firmware/rtl8822cu_fw \
+"
+
+# Prevent the following issue when running yocto-check-layer:
+# The machines have conflicting signatures for some shared tasks
+COMPATIBLE_MACHINE = "^tegra234$"


### PR DESCRIPTION
Make symbolic links for `/usr/lib/firmware/rtl8822cu_fw` and `/usr/lib/firmware/rtl8822cu_config` in `linux-firmware-rtl8822` to avoid the following Bluetooth issue experienced on machine `jetson-orin-nano-devkit-nvme` when using a kernel provided by recipe `linux-yocto`:

```
root@jetson-orin-nano-devkit-nvme:~# hciconfig hci0 up rtk_btusb: chip type value: 0x73
rtk_btusb: config filename rtl8822cu_config
usb 1-3: Direct firmware load for rtl8822cu_config failed with error -2
usb 1-3: Direct firmware load for rtl8822cu_fw failed with error -2
Can't init device hci0: Input/output error (5)
```

This is related to the changes from commit 944504c.

My build setup for this test and fix is:

```
mkdir tegra-master
cd tegra-master
git clone git://git.openembedded.org/openembedded-core
git clone git://git.openembedded.org/bitbake
git clone git://git.yoctoproject.org/meta-yocto
git clone git://git.openembedded.org/meta-openembedded
git clone https://github.com/OE4T/meta-tegra.git
source openembedded-core/oe-init-build-env build
bitbake-layers add-layer ../meta-yocto/meta-poky
bitbake-layers add-layer ../meta-yocto/meta-yocto-bsp
bitbake-layers add-layer ../meta-openembedded/meta-oe
bitbake-layers add-layer ../meta-openembedded/meta-python
bitbake-layers add-layer ../meta-openembedded/meta-networking
bitbake-layers add-layer ../meta-openembedded/meta-multimedia
bitbake-layers add-layer ../meta-tegra
```
In `local.conf` I added:
```
MACHINE = "jetson-orin-nano-devkit-nvme"

DISTRO_FEATURES:append = " systemd pam"
DISTRO_FEATURES:remove = "sysvinit"

# Use systemd as init manager
INIT_MANAGER = "systemd"

EXTRA_IMAGE_FEATURES = "allow-empty-password empty-root-password allow-root-login"
```