### PR TITLE
tegra-minimal-init: use TNSPEC_BOOTDEV to locate APP/APP_b partition

### DIFF
--- a/recipes-core/initrdscripts/tegra-minimal-init/platform-preboot.sh
+++ b/recipes-core/initrdscripts/tegra-minimal-init/platform-preboot.sh
@@ -1,6 +1,7 @@
 slotsfx=""
 mayberoot=""
 foundslotsfx="no"
+bootdrive=@@BOOTDRIVE@@
 for bootarg in `cat /proc/cmdline`; do
     case "$bootarg" in
         boot.slot_suffix=*) slotsfx="${bootarg##boot.slot_suffix=}"; foundslotsfx="yes" ;;
@@ -22,7 +23,7 @@ if [ "$foundslotsfx" != "yes" ]; then
     message="Waiting for APP$slotsfx partition..."
     for count in $(seq 1 10); do
         blkid --probe 2>/dev/null
-        rootdev=`blkid -l -t PARTLABEL=APP$slotsfx | cut -d: -f1`
+        rootdev=`blkid -t PARTLABEL=APP$slotsfx | grep "^$bootdrive" | cut -d: -f1`
         if [ -n "$rootdev" ]; then
             echo "[OK: $rootdev]"
             break

--- a/recipes-core/initrdscripts/tegra-minimal-init_1.0.bb
+++ b/recipes-core/initrdscripts/tegra-minimal-init_1.0.bb
@@ -13,6 +13,19 @@ COMPATIBLE_MACHINE = "(tegra)"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
+def boot_drive(d):
+    import re
+    bootdev = d.getVar('TNSPEC_BOOTDEV') or 'internal'
+    if bootdev not in ['internal','external']:
+        m = re.match('^(mmcblk[0-9]+)p[0-9]+', bootdev) or \
+            re.match('^(nvme[0-9]+n[0-9]+)p[0-9]+', bootdev) or \
+            re.match('^(sd[a-z])[0-9]+', bootdev)
+        if m is not None:
+            return "/dev/" + m.group(1)
+    return ''
+
+TEGRA_MINIMAL_INIT_BOOTDRIVE ??= "${@boot_drive(d)}"
+
 do_install() {
     install -m 0755 ${UNPACKDIR}/init-boot.sh ${D}/init
     install -m 0555 -d ${D}/proc ${D}/sys
@@ -21,7 +34,9 @@ do_install() {
     mknod -m 622 ${D}/dev/console c 5 1
     install -d ${D}${sysconfdir}
     install -m 0644 ${UNPACKDIR}/platform-preboot.sh ${D}${sysconfdir}/platform-preboot
-    sed -i -e "s#@@TNSPEC_BOOTDEV@@#${TNSPEC_BOOTDEV}#g" ${D}${sysconfdir}/platform-preboot
+    sed -i -e "s#@@TNSPEC_BOOTDEV@@#${TNSPEC_BOOTDEV}#g" \
+	-e "s#@@BOOTDRIVE@@#${TEGRA_MINIMAL_INIT_BOOTDRIVE}#g" \
+	${D}${sysconfdir}/platform-preboot
 }
 
 RDEPENDS:${PN} = "util-linux-blkid kmod"


### PR DESCRIPTION
which allows for booting off the correct drive when switching between, say, and NVMe drive and some other storage medium, both containing the usual partition layout.