### PR TITLE
optee: add option to build fTPM components

### DIFF
--- a/recipes-security/optee/optee-client/tee-ftpm-modprobe.service
+++ b/recipes-security/optee/optee-client/tee-ftpm-modprobe.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Load fTPM Module
+After=tee-supplicant.service
+BindsTo=tee-supplicant.service
+ConditionPathExists=/dev/teepriv0
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=modprobe --ignore-install tpm_ftpm_tee
+ExecStop=modprobe -r tpm_ftpm_tee
+
+[Install]
+WantedBy=tee-supplicant.service

--- a/recipes-security/optee/optee-client/tee-supplicant.service.in
+++ b/recipes-security/optee/optee-client/tee-supplicant.service.in
@@ -2,6 +2,7 @@
 Description=TEE Supplicant
 
 [Service]
+Type=exec
 User=root
 EnvironmentFile=-@sysconfdir@/default/tee-supplicant
 ExecStart=@sbindir@/tee-supplicant $OPTARGS

--- a/recipes-security/optee/optee-client/tee-supplicant.sh.in
+++ b/recipes-security/optee/optee-client/tee-supplicant.sh.in
@@ -6,6 +6,7 @@ DESC="OP-TEE Supplicant"
 
 DAEMON=@sbindir@/$NAME
 OPTARGS=
+FTPM_ENABLED="@OPTEE_ENABLE_FTPM@"
 
 test -f $DAEMON || exit 0
 
@@ -21,8 +22,16 @@ case $1 in
 	    echo -n "Starting $DESC: "
 	    start-stop-daemon --start $SSD_OPTIONS
         echo "${DAEMON##*/}."
+        if [ "${FTPM_ENABLED}" = "1" ]; then
+            echo "Loading tpm_ftpm_tee"
+            modprobe -v --ignore-install tpm_ftpm_tee
+        fi
         ;;
     stop)
+        if [ "${FTPM_ENABLED}" = "1" ]; then
+            echo "Unloading tpm_ftpm_tee"
+            modprobe -v -r tpm_ftpm_tee
+        fi
 	    echo -n "Stopping $DESC: "
 	    start-stop-daemon --stop $SSD_OPTIONS
         echo "${DAEMON##*/}."

--- a/recipes-security/optee/optee-client_4.2-l4t-r36.5.0.bb
+++ b/recipes-security/optee/optee-client_4.2-l4t-r36.5.0.bb
@@ -14,6 +14,7 @@ SRC_URI += "\
     file://0001-Update-Makefile-for-OE-compatibility.patch;striplevel=3 \
     file://tee-supplicant.service.in \
     file://tee-supplicant.sh.in \
+    file://tee-ftpm-modprobe.service \
 "
 
 DEPENDS = "optee-os-tadevkit util-linux-libuuid"
@@ -35,6 +36,7 @@ do_compile() {
     sed -e's,@sbindir@,${sbindir},g' \
         -e's,@sysconfdir@,${sysconfdir},g' \
         -e's,@stripped_path@,${base_sbindir}:${base_bindir}:${sbindir}:${bindir},g' \
+        -e's,@OPTEE_ENABLE_FTPM@,${OPTEE_ENABLE_FTPM},g' \
         ${WORKDIR}/tee-supplicant.sh.in >${B}/tee-supplicant.sh
 }
 
@@ -43,9 +45,13 @@ do_install() {
     install -d ${D}${systemd_system_unitdir} ${D}${sysconfdir}/init.d
     install -m 0644 ${B}/tee-supplicant.service ${D}${systemd_system_unitdir}/
     install -m 0755 ${B}/tee-supplicant.sh ${D}${sysconfdir}/init.d/tee-supplicant
+
+    if [ "${OPTEE_ENABLE_FTPM}" = "1" ]; then
+        install -m 0644 ${WORKDIR}/tee-ftpm-modprobe.service ${D}${systemd_system_unitdir}/
+    fi
 }
 
-SYSTEMD_SERVICE:${PN} = "tee-supplicant.service"
+SYSTEMD_SERVICE:${PN} = "tee-supplicant.service ${@'tee-ftpm-modprobe.service' if d.getVar('OPTEE_ENABLE_FTPM') == '1' else ''}"
 INITSCRIPT_PACKAGES = "${PN}"
 INITSCRIPT_NAME:${PN} = "tee-supplicant"
 INITSCRIPT_PARAMS:${PN} = "start 10 1 2 3 4 5 . stop 90 0 6 ."

--- a/recipes-security/optee/optee-l4t.inc
+++ b/recipes-security/optee/optee-l4t.inc
@@ -15,6 +15,14 @@ OPTEE_NV_PLATFORM:tegra234 = "t234"
 
 TA_DEV_KIT_DIR = "${STAGING_INCDIR}/optee/export-user_ta"
 
+OPTEE_ENABLE_FTPM ?= "0"
+
+FTPM_CFG = " \
+    CFG_CORE_TPM_EVENT_LOG=y \
+    CFG_REE_STATE=y \
+    CFG_JETSON_FTPM_HELPER_PTA=y \
+"
+
 # Common to all of the builds
 EXTRA_OEMAKE = "\
     V=1 \

--- a/recipes-security/optee/optee-nvsamples/0001-Update-makefiles-for-OE-builds.patch
+++ b/recipes-security/optee/optee-nvsamples/0001-Update-makefiles-for-OE-builds.patch
@@ -1,28 +1,29 @@
-From a96f5ccf52879d9ad045bf749d2a0a32508ec9ee Mon Sep 17 00:00:00 2001
+From 7e3ffa3c1f05a276d68d0f28f020cb416092e961 Mon Sep 17 00:00:00 2001
 From: Ilies CHERGUI <ichergui@nvidia.com>
 Date: Sun, 6 Oct 2024 20:17:01 +0100
 Subject: [PATCH] Update makefiles for OE builds
 
 - Remove the OPTEE_CLIENT_EXPORT references
 - Use install instead of cp to install host programs
-- Add LDFLAGS to nvhwkey-app build
+- Add LDFLAGS to nvhwkey-app & nvftpm-helper-app build
 
 Upstream-Status: Inappropriate [OE-Specific]
 
 Signed-off-by: Matt Madison <matt@madison.systems>
 Signed-off-by: Ilies CHERGUI <ichergui@nvidia.com>
+Signed-off-by: dolwup <dol@wup.sh>
 ---
  Makefile                    |  4 ----
  cpubl-payload-dec/Makefile  |  2 --
  ftpm-helper/Makefile        |  4 ----
- ftpm-helper/host/Makefile   | 13 +++++--------
+ ftpm-helper/host/Makefile   | 15 ++++++---------
  hwkey-agent/Makefile        |  4 ----
  hwkey-agent/host/Makefile   | 15 ++++++---------
  luks-srv/Makefile           |  4 ----
  luks-srv/host/Makefile      | 14 +++++---------
  pkcs11-sample/Makefile      |  4 ----
  pkcs11-sample/host/Makefile | 11 +++++------
- 10 files changed, 21 insertions(+), 54 deletions(-)
+ 10 files changed, 22 insertions(+), 55 deletions(-)
 
 diff --git a/Makefile b/Makefile
 index da3f40b..7671e2d 100644
@@ -96,10 +97,10 @@ index 1069464..62cb216 100644
  		clean
  	rm -rf $(O)/ca/$(TARGET_DIR)
 diff --git a/ftpm-helper/host/Makefile b/ftpm-helper/host/Makefile
-index 33ca6da..ac63623 100644
+index 33ca6da..feb4041 100644
 --- a/ftpm-helper/host/Makefile
 +++ b/ftpm-helper/host/Makefile
-@@ -3,24 +3,21 @@
+@@ -3,27 +3,24 @@
  
  # Input variables
  # CROSS_COMPILE: The cross compiler.
@@ -125,7 +126,11 @@ index 33ca6da..ac63623 100644
 +all: $(BINARY)
  
  $(BINARY): $(OBJS)
- 	$(CC) -o $(O)/$@ $< $(LDADD)
+-	$(CC) -o $(O)/$@ $< $(LDADD)
++	$(CC) $(LDFLAGS) -o $(O)/$@ $< $(LDADD)
+ 	$(STRIP) $(O)/$@
+ 
+ $(O)/%.o: %.c
 @@ -31,9 +28,9 @@ $(O)/%.o: %.c
  	$(CC) $(CFLAGS) -c $< -o $@
  
@@ -357,6 +362,3 @@ index 6212e02..a8285b4 100644
  clean:
 -	rm -f $(OBJS) $(O)/$(BINARY) $(OPTEE_CLIENT_EXPORT)/sbin/$(BINARY)
 +	rm -f $(OBJS) $(O)/$(BINARY)
--- 
-2.34.1
-

--- a/recipes-security/optee/optee-nvsamples_36.5.0.bb
+++ b/recipes-security/optee/optee-nvsamples_36.5.0.bb
@@ -5,6 +5,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=6938d70d5e5d49d31049419e85bb82f8"
 
 require optee-l4t.inc
 TEGRA_SRC_SUBARCHIVE_OPTS = "--strip-components=1 optee/samples"
+TEGRA_SRC_SUBARCHIVE_OPTS += "--strip-components=1 optee/optee_os"
 
 SRC_URI += " file://0001-Update-makefiles-for-OE-builds.patch"
 
@@ -18,10 +19,20 @@ export LDADD
 S = "${WORKDIR}/samples"
 B = "${WORKDIR}/build"
 
-EXTRA_OEMAKE += "CROSS_COMPILE=${HOST_PREFIX}"
+EXTRA_OEMAKE += " \
+    CROSS_COMPILE=${HOST_PREFIX} \
+    ${@d.getVar('FTPM_CFG', True) if d.getVar('OPTEE_ENABLE_FTPM') == '1' else ''} \
+"
+
+MS_TPM_SRC = "${S}/ms-tpm-20-ref/Samples/ARM32-FirmwareTPM/optee_ta"
+OPTEE_OS_S = "${WORKDIR}/optee_os"
 
 do_compile() {
     oe_runmake -C ${S} all
+    
+    if [ "${OPTEE_ENABLE_FTPM}" = "1" ]; then
+        oe_runmake -C "${MS_TPM_SRC}" CFG_TA_MEASURED_BOOT=y CFG_USE_PLATFORM_EPS=y OPTEE_OS_DIR=${OPTEE_OS_S}
+    fi
 }
 do_compile[cleandirs] = "${B}"
 
@@ -33,12 +44,19 @@ do_install() {
     install -D -m 0755 ${B}/early_ta/luks-srv/b83d14a8-7128-49df-9624-35f14f65ca6c.stripped.elf -t ${D}${includedir}/optee/early_ta/luks-srv
     install -D -m 0755 ${B}/early_ta/cpubl-payload-dec/0e35e2c9-b329-4ad9-a2f5-8ca9bbbd7713.stripped.elf -t ${D}${includedir}/optee/early_ta/cpubl-payload-dec
     oe_runmake -C ${S}/luks-srv/host install DESTDIR="${D}"
+
+    if [ "${OPTEE_ENABLE_FTPM}" = "1" ]; then
+        install -D -m 0755 ${B}/early_ta/ftpm-helper/a6a3a74a-77cb-433a-990c-1dfb8a3fbc4c.stripped.elf -t ${D}${includedir}/optee/early_ta/ftpm-helper
+        install -D -m 0755 ${B}/early_ta/ms-tpm/bc50d971-d4c9-42c4-82cb-343fb7f37896.stripped.elf -t ${D}${includedir}/optee/early_ta/ms-tpm
+        oe_runmake -C ${S}/ftpm-helper/host install DESTDIR="${D}"
+    fi
 }
 
-PACKAGES =+ "${PN}-luks-srv ${PN}-hwkey-agent"
+PACKAGES =+ "${PN}-luks-srv ${PN}-hwkey-agent ${@d.getVar('PN') + '-ftpm-helper' if d.getVar('OPTEE_ENABLE_FTPM') == '1' else ''}"
 FILES:${PN}-hwkey-agent = "${nonarch_base_libdir}/optee_armtz/82154947-c1bc-4bdf-b89d-04f93c0ea97c.ta ${sbindir}/nvhwkey-app"
 FILES:${PN}-luks-srv = "${sbindir}/nvluks-srv-app"
+FILES:${PN}-ftpm-helper = "${sbindir}/nvftpm-helper-app"
 ALLOW_EMPTY:${PN} = "1"
-RDEPENDS:${PN} = "${PN}-luks-srv ${PN}-hwkey-agent"
+RDEPENDS:${PN} = "${PN}-luks-srv ${PN}-hwkey-agent ${@d.getVar('PN') + '-ftpm-helper' if d.getVar('OPTEE_ENABLE_FTPM') == '1' else ''}"
 INHIBIT_SYSROOT_STRIP = "1"
 INSANE_SKIP:${PN} = "already-stripped"

--- a/recipes-security/optee/optee-nvsamples_36.5.0.bb
+++ b/recipes-security/optee/optee-nvsamples_36.5.0.bb
@@ -57,6 +57,14 @@ FILES:${PN}-hwkey-agent = "${nonarch_base_libdir}/optee_armtz/82154947-c1bc-4bdf
 FILES:${PN}-luks-srv = "${sbindir}/nvluks-srv-app"
 FILES:${PN}-ftpm-helper = "${sbindir}/nvftpm-helper-app"
 ALLOW_EMPTY:${PN} = "1"
-RDEPENDS:${PN} = "${PN}-luks-srv ${PN}-hwkey-agent ${@d.getVar('PN') + '-ftpm-helper' if d.getVar('OPTEE_ENABLE_FTPM') == '1' else ''}"
+RDEPENDS:${PN} = " \
+    ${PN}-luks-srv \
+    ${PN}-hwkey-agent \
+    ${@ \
+        d.getVar('PN') + '-ftpm-helper' \
+        + ' kernel-module-tpm-ftpm-tee' \
+    if d.getVar('OPTEE_ENABLE_FTPM') == '1' else ''} \
+"
+RRECOMMENDS:${PN} = " ${@ 'tegra-configs-udev' if d.getVar('OPTEE_ENABLE_FTPM') == '1' else ''}"
 INHIBIT_SYSROOT_STRIP = "1"
 INSANE_SKIP:${PN} = "already-stripped"

--- a/recipes-security/optee/optee-os_4.2-l4t-r36.5.0.bb
+++ b/recipes-security/optee/optee-os_4.2-l4t-r36.5.0.bb
@@ -8,9 +8,16 @@ CVE_PRODUCT = "linaro:op-tee op-tee:op-tee_os"
 
 DEPENDS += "optee-nvsamples"
 
+EARLY_TA_PATHS_FTPM = " \
+                        ${STAGING_INCDIR}/optee/early_ta/ftpm-helper/a6a3a74a-77cb-433a-990c-1dfb8a3fbc4c.stripped.elf \
+                        ${STAGING_INCDIR}/optee/early_ta/ms-tpm/bc50d971-d4c9-42c4-82cb-343fb7f37896.stripped.elf \
+"
+
 EXTRA_OEMAKE += "\
     EARLY_TA_PATHS='${STAGING_INCDIR}/optee/early_ta/cpubl-payload-dec/0e35e2c9-b329-4ad9-a2f5-8ca9bbbd7713.stripped.elf \
-                    ${STAGING_INCDIR}/optee/early_ta/luks-srv/b83d14a8-7128-49df-9624-35f14f65ca6c.stripped.elf' \
+                    ${STAGING_INCDIR}/optee/early_ta/luks-srv/b83d14a8-7128-49df-9624-35f14f65ca6c.stripped.elf \
+                    ${@d.getVar('EARLY_TA_PATHS_FTPM', True) if d.getVar('OPTEE_ENABLE_FTPM') == '1' else ''}' \
+    ${@d.getVar('FTPM_CFG', True) if d.getVar('OPTEE_ENABLE_FTPM') == '1' else ''} \
 "
 
 do_install() {


### PR DESCRIPTION
NVIDIA provides the ability to build Firmware TPM Support into OP-TEE by specifying -t to their build script in the l4t optee sources. This is a replication of what this flag does.

Adds OPTEE_ENABLE_FTPM_BUILD as a variable (default: 1) to enable/disable fTPM support. Depending on this variable build and install the ftpm-helper and ms-tpm TAs as well as the nvftpm-helper-app CA (for provisioning).