### PR TITLE
image_types_tegra: rename tegraflash.tar to tegraflash-tar

### DIFF
--- a/classes-recipe/image_types_tegra.bbclass
+++ b/classes-recipe/image_types_tegra.bbclass
@@ -4,7 +4,7 @@ TEGRA_UEFI_SIGNING_CLASS ??= "tegra-uefi-signing"
 inherit ${TEGRA_UEFI_SIGNING_CLASS}
 TEGRA_UEFI_USE_SIGNED_FILES ??= "false"
 
-IMAGE_TYPES += "tegraflash.tar"
+IMAGE_TYPES += "tegraflash-tar"
 
 IMAGE_ROOTFS_ALIGNMENT ?= "4"
 
@@ -195,8 +195,8 @@ tegraflash_custom_post() {
 }
 
 tegraflash_finalize_pkg() {
-    rm -f ${IMGDEPLOYDIR}/${IMAGE_NAME}.tegraflash.tar
-    ${IMAGE_CMD_TAR} --sparse --numeric-owner --transform="s,^\./,," -cf ${IMGDEPLOYDIR}/${IMAGE_NAME}.tegraflash.tar .
+    rm -f ${IMGDEPLOYDIR}/${IMAGE_NAME}.tegraflash-tar
+    ${IMAGE_CMD_TAR} --sparse --numeric-owner --transform="s,^\./,," -cf ${IMGDEPLOYDIR}/${IMAGE_NAME}.tegraflash-tar .
 }
 
 tegraflash_create_flash_config() {
@@ -455,7 +455,7 @@ EOF
     chmod +x $outfile
 }
 
-IMAGE_CMD:tegraflash.tar = "create_tegraflash_pkg"
+IMAGE_CMD:tegraflash-tar = "create_tegraflash_pkg"
 do_image_tegraflash_tar[depends] += "dtc-native:do_populate_sysroot coreutils-native:do_populate_sysroot \
                                  tegra-flashtools-native:do_populate_sysroot gptfdisk-native:do_populate_sysroot \
                                  tegra-bootfiles:do_populate_sysroot tegra-bootfiles:do_populate_lic \
@@ -465,4 +465,4 @@ do_image_tegraflash_tar[depends] += "dtc-native:do_populate_sysroot coreutils-na
                                  virtual/bootloader:do_deploy virtual/secure-os:do_deploy \
 				 ${TEGRA_RCM_EDK2_DEPENDS} ${TEGRA_SIGNING_EXTRA_DEPS} ${DTB_EXTRA_DEPS} \
                                  ${@'${TEGRAFLASH_INITRD_FLASH_IMAGE}:do_image_complete' if d.getVar('TEGRAFLASH_INITRD_FLASH_IMAGE') != '' else ''}"
-IMAGE_TYPEDEP:tegraflash.tar += "${IMAGE_TEGRAFLASH_FS_TYPE}"
+IMAGE_TYPEDEP:tegraflash-tar += "${IMAGE_TEGRAFLASH_FS_TYPE}"

--- a/conf/machine/include/tegra-common.inc
+++ b/conf/machine/include/tegra-common.inc
@@ -65,7 +65,7 @@ IMAGE_ROOTFS_ALIGNMENT ?= "4"
 TEGRA_BLBLOCKSIZE ?= "${@int(d.getVar('IMAGE_ROOTFS_ALIGNMENT')) * 1024}"
 EXTRA_IMAGECMD:ext4 ?= "-i 4096 -b 4096"
 IMAGE_CLASSES += "image_types_tegra"
-IMAGE_FSTYPES += "tegraflash.tar.zst"
+IMAGE_FSTYPES += "tegraflash-tar.zst"
 
 INITRAMFS_IMAGE ?= "tegra-minimal-initramfs"
 INITRAMFS_IMAGE_BUNDLE ?= "0"

--- a/docs/Tegraflash-enhancements.md
+++ b/docs/Tegraflash-enhancements.md
@@ -1,3 +1,10 @@
+# Update: 21 Apr 2026
+
+In the `master` branch:
+* The image type for tegraflash packages has been changed from `tegraflash.tar` to `tegraflash-tar`.
+* The default for `IMAGE_FSTYPES` has been changed from `tegraflash.tar.zst` to `tegraflash-tar.zst`.
+Both to fix `.tar` suffix parsing with latest oe-core: https://github.com/OE4T/meta-tegra/issues/2191
+
 # Update: 10 Feb 2025
 
 In the `master` branch:


### PR DESCRIPTION
Using ".tar" suffix causes tar to be parsed as image conversion.

After:
https://git.openembedded.org/openembedded-core/commit/?id=76316c765d3183f7ecbf8e83c514c392d5a86eed

it causes parsing failure:

No CONVERSION_CMD defined for subtype "tar" - possibly invalid conversion type name or missing support class

It's discussed on ML in:
https://lists.openembedded.org/g/openembedded-core/topic/118885182#msg235513

Fixes: https://github.com/OE4T/meta-tegra/issues/2191