### PR TITLE
edk2-firmware-tegra: remove do_qa_patch from do_patch postfuncs

### DIFF
--- a/recipes-bsp/uefi/edk2-firmware-core-tegra-36.5.0.inc
+++ b/recipes-bsp/uefi/edk2-firmware-core-tegra-36.5.0.inc
@@ -9,3 +9,17 @@ SRCREV_edk2 = "30419afc4a6ea666434f9275057f579b46a07a5f"
 SRC_URI = "${SRC_URI_EDK2};name=edk2;destsuffix=edk2-tegra/edk2"
 
 S = "${UNPACKDIR}/edk2-tegra/edk2"
+
+# XXX
+# Remove do_qa_patch from the do_patch postfuncs list
+# to avoid the potential for throwing an exception when
+# the unimplemented-ptest checker walks the source tree
+# and finds a directory named 'common.py' that it tries
+# to process as a file.
+# See https://github.com/OE4T/meta-tegra/issues/2201
+# XXX
+python() {
+    patch_postfuncs = (d.getVarFlag('do_patch', 'postfuncs') or "").split()
+    new_postfuncs = [f for f in patch_postfuncs if f != 'do_qa_patch']
+    d.setVarFlag('do_patch', 'postfuncs', ' '.join(new_postfuncs))
+}


### PR DESCRIPTION
to prevent an exception being thrown by the code in that function that assumes that anything ending with '.py' is a file, rather than a directory, which isn't true for the oqs-provider sub-sub-submodule under edk2.

Fixes #2201 